### PR TITLE
Correct `over` functionality for multi-op specs

### DIFF
--- a/kazaam.go
+++ b/kazaam.go
@@ -116,6 +116,11 @@ func (j *Kazaam) Transform(data *simplejson.Json) (*simplejson.Json, error) {
 				transformedDataList = append(transformedDataList, transformedData)
 			}
 			data.SetPath(strings.Split(*specObj.Over, "."), transformedDataList)
+
+			// Marshal+Parse JSON to remove object nesting artifacts added while processing `Over`
+			tmp, _ := data.MarshalJSON()
+			data, _ = simplejson.NewJson([]byte(tmp))
+
 		} else {
 			data, err = getTransform(specObj)(&specObj, data)
 		}

--- a/kazaam_test.go
+++ b/kazaam_test.go
@@ -440,9 +440,32 @@ func TestKazaamConcatTransformMulti(t *testing.T) {
 
 func TestKazaamConcatTransformSingle(t *testing.T) {
 	spec := `[{"operation": "concat", "spec": {"sources": [{"path": "a.timestamp"}], "targetPath": "a.output" }}]`
-	jsonIn := `{"a":{"timestamp": 1481305274}}`
+	jsonIn := `{"a":{"timestamp": 1481305274100000000000000000000}}`
 
-	jsonOut := `{"a":{"output":"1481305274","timestamp":1481305274}}`
+	jsonOut := `{"a":{"output":"1481305274100000000000000000000","timestamp":1481305274100000000000000000000}}`
+
+	kazaamTransform, _ := kazaam.NewKazaam(spec)
+	kazaamOut, _ := kazaamTransform.TransformJSONStringToString(jsonIn)
+
+	if kazaamOut != jsonOut {
+		t.Error("Transformed data does not match expectation.")
+		t.Log("Expected: ", jsonOut)
+		t.Log("Actual:   ", kazaamOut)
+		t.FailNow()
+	}
+}
+
+func TestKazaamTransformMultiOpWithOver(t *testing.T) {
+	spec := `[{
+		"operation": "concat",
+		"over": "a",
+		"spec": {"sources": [{"path": "foo"}, {"value": "KEY"}], "targetPath": "url", "delim": ":" }
+	}, {
+		"operation": "shift",
+		"spec": {"urls": "a[*].url" }
+	}]`
+	jsonIn := `{"a":[{"foo": 0}, {"foo": 1}, {"foo": 2}]}`
+	jsonOut := `{"urls":["0:KEY","1:KEY","2:KEY"]}`
 
 	kazaamTransform, _ := kazaam.NewKazaam(spec)
 	kazaamOut, _ := kazaamTransform.TransformJSONStringToString(jsonIn)


### PR DESCRIPTION
Added Marshalling and Re-parsing of intermediate JSON to remove object nesting artifacts added while processing `Over`