### PR TITLE
Add experimental fast json validation

### DIFF
--- a/kazaam.go
+++ b/kazaam.go
@@ -166,16 +166,6 @@ func transformErrorType(err error) error {
 	}
 }
 
-// by default, kazaam does not fully validate input data. Use IsJson()
-// if you need to confirm input is valid before transforming.
-// Note: This operation is very slow and memory/alloc intensive
-// relative to most transforms.
-func IsJson(s []byte) bool {
-	var js map[string]interface{}
-	return json.Unmarshal(s, &js) == nil
-
-}
-
 // Transform makes a copy of the byte slice `data`, transforms it according
 // to the loaded spec, and returns the new, modified byte slice.
 func (k *Kazaam) Transform(data []byte) ([]byte, error) {
@@ -195,7 +185,7 @@ func (k *Kazaam) TransformInPlace(data []byte) ([]byte, error) {
 	if k == nil || k.specJSON == nil {
 		return data, &Error{ErrMsg: "Kazaam not properly initialized", ErrType: SpecError}
 	}
-	if len(data)==0 {
+	if len(data) == 0 {
 		return data, nil
 	}
 

--- a/kazaam_benchmarks_test.go
+++ b/kazaam_benchmarks_test.go
@@ -10,6 +10,10 @@ const (
 	benchmarkJSON = `{"topKeyA": {"arrayKey": [{"foo": 0}, {"foo": 1}, {"foo": 1}, {"foo": 2}], "notArrayKey": "bar", "deepArrayKey": [{"key0":["val0", "val1"]}]}, "topKeyB":{"nextKeyB": "valueB"}}`
 )
 
+var (
+	benchmarkSlice = []byte(benchmarkJSON)
+)
+
 // Just for emulating field access, so it will not throw "evaluated but not
 // used." Borrowed from:
 // https://github.com/buger/jsonparser/blob/master/benchmark/benchmark_small_payload_test.go
@@ -262,6 +266,18 @@ func BenchmarkExtractTransformOnly(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		kazaamOut, _ := transform.TransformJSONStringToString(benchmarkJSON)
 		nothing(kazaamOut)
+	}
+
+}
+
+func BenchmarkIsJsonFast(b *testing.B) {
+	b.ReportAllocs()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		val := kazaam.IsJsonFast(benchmarkSlice)
+		nothing(val)
 	}
 
 }

--- a/kazaam_int_test.go
+++ b/kazaam_int_test.go
@@ -132,12 +132,16 @@ func TestKazaamCoalesceTransformAndShift(t *testing.T) {
 		"operation": "shift",
 		"spec": {"rating.foo": "foo", "rating.example.value": "rating.primary.value"}
 	}]`
+
+	// for some reason, keys are inserted in different order on different runs locally and in CI
+	// so without the alt we get sporadic failures.
 	jsonOut := `{"rating":{"foo":{"value":3},"example":{"value":3}}}`
+	altJsonOut := `{"rating":{"example":{"value":3},"foo":{"value":3}}}`
 
 	kazaamTransform, _ := kazaam.NewKazaam(spec)
 	kazaamOut, _ := kazaamTransform.TransformJSONStringToString(testJSONInput)
 
-	if kazaamOut != jsonOut {
+	if kazaamOut != jsonOut && kazaamOut != altJsonOut {
 		t.Error("Transformed data does not match expectation.")
 		t.Log("Expected: ", jsonOut)
 		t.Log("Actual:   ", kazaamOut)

--- a/util.go
+++ b/util.go
@@ -1,0 +1,61 @@
+package kazaam
+
+import (
+	"encoding/json"
+
+	"github.com/JoshKCarroll/jsonparser"
+)
+
+// by default, kazaam does not fully validate input data. Use IsJson()
+// if you need to confirm input is valid before transforming.
+// Note: This operation is very slow and memory/alloc intensive
+// relative to most transforms.
+func IsJson(s []byte) bool {
+	var js map[string]interface{}
+	return json.Unmarshal(s, &js) == nil
+
+}
+
+// experimental fast validation with jsonparser
+func IsJsonFast(s []byte) bool {
+	for _, c := range s {
+		switch c {
+		case ' ', '\n', '\r', '\t':
+			continue
+		case '{':
+			return isJsonInternal(s, jsonparser.Object)
+		case '[':
+			return isJsonInternal(s, jsonparser.Array)
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func isJsonInternal(s []byte, t jsonparser.ValueType) bool {
+	valid := true
+	if t == jsonparser.Array {
+		_, err := jsonparser.ArrayEach(s, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+			if valid {
+				valid = isJsonInternal(value, dataType)
+			}
+		})
+		if err != nil || !valid {
+			return false
+		}
+	} else if t == jsonparser.Object {
+		err := jsonparser.ObjectEach(s, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
+			if valid {
+				valid = isJsonInternal(value, dataType)
+			}
+			return nil
+		})
+		if err != nil || !valid {
+			return false
+		}
+	} else if t == jsonparser.Unknown {
+		return false
+	}
+	return valid
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,108 @@
+package kazaam
+
+import (
+	"testing"
+)
+
+type IsJsonTest struct {
+	json    string
+	valid   bool
+	isArray bool // encoding/json IsJson() does not support arrays
+}
+
+var jsonTests = []IsJsonTest{
+	{
+		json:  `{"key":"value"}`,
+		valid: true,
+	},
+	{
+		json:  `{"bad-data"}`,
+		valid: false,
+	},
+	{
+		json:  `{"text": "RT @PostGradProblem: In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during ...","truncated": true,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54691802283900928","entities": {"user_mentions": [{"indices": [3,19],"screen_name": "PostGradProblem","id_str": "271572434","name": "PostGradProblems","id": 271572434}],"urls": [ ],"hashtags": [ ]},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 23:48:36 +0000 2011","retweeted_status": {"text": "In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during company time. #PGP","truncated": false,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54640519019642881","entities": {"user_mentions": [ ],"urls": [ ],"hashtags": [{"text": "PGP","indices": [130,134]}]},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 20:24:49 +0000 2011","user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 31,"profile_background_color": "C0DEED","followers_count": 3066,"profile_image_url": "http://a2.twimg.com/profile_images/1285770264/PGP_normal.jpg","listed_count": 6,"profile_background_image_url": "http://a3.twimg.com/a/1301071706/images/themes/theme1/bg.png","description": "","screen_name": "PostGradProblem","default_profile": true,"verified": false,"time_zone": null,"profile_text_color": "333333","is_translator": false,"profile_sidebar_fill_color": "DDEEF6","location": "","id_str": "271572434","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 21,"protected": false,"favourites_count": 0,"created_at": "Thu Mar 24 19:45:44 +0000 2011","profile_link_color": "0084B4","name": "PostGradProblems","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 271572434,"contributors_enabled": false,"following": null,"utc_offset": null},"id": 54640519019642880,"coordinates": null,"geo": null},"user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 351,"profile_background_color": "C0DEED","followers_count": 48,"profile_image_url": "http://a1.twimg.com/profile_images/455128973/gCsVUnofNqqyd6tdOGevROvko1_500_normal.jpg","listed_count": 0,"profile_background_image_url": "http://a3.twimg.com/a/1300479984/images/themes/theme1/bg.png","description": "watcha doin in my waters?","screen_name": "OldGREG85","default_profile": true,"verified": false,"time_zone": "Hawaii","profile_text_color": "333333","is_translator": false,"profile_sidebar_fill_color": "DDEEF6","location": "Texas","id_str": "80177619","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 81,"protected": false,"favourites_count": 0,"created_at": "Tue Oct 06 01:13:17 +0000 2009","profile_link_color": "0084B4","name": "GG","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 80177619,"contributors_enabled": false,"following": null,"utc_offset": -36000},"id": 54691802283900930,"coordinates": null,"geo": null}`,
+		valid: true,
+	},
+	{
+		// ,"profile_text_color": "333333","is_translator: false,"profile_sidebar_fill_color": "DDEEF6",
+		json:  `{"text": "RT @PostGradProblem: In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during ...","truncated": true,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54691802283900928","entities": {"user_mentions": [{"indices": [3,19],"screen_name": "PostGradProblem","id_str": "271572434","name": "PostGradProblems","id": 271572434}],"urls": [ ],"hashtags": [ ]},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 23:48:36 +0000 2011","retweeted_status": {"text": "In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during company time. #PGP","truncated": false,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54640519019642881","entities": {"user_mentions": [ ],"urls": [ ],"hashtags": [{"text": "PGP","indices": [130,134]}]},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 20:24:49 +0000 2011","user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 31,"profile_background_color": "C0DEED","followers_count": 3066,"profile_image_url": "http://a2.twimg.com/profile_images/1285770264/PGP_normal.jpg","listed_count": 6,"profile_background_image_url": "http://a3.twimg.com/a/1301071706/images/themes/theme1/bg.png","description": "","screen_name": "PostGradProblem","default_profile": true,"verified": false,"time_zone": null,"profile_text_color": "333333","is_translator": false,"profile_sidebar_fill_color": "DDEEF6","location": "","id_str": "271572434","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 21,"protected": false,"favourites_count": 0,"created_at": "Thu Mar 24 19:45:44 +0000 2011","profile_link_color": "0084B4","name": "PostGradProblems","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 271572434,"contributors_enabled": false,"following": null,"utc_offset": null},"id": 54640519019642880,"coordinates": null,"geo": null},"user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 351,"profile_background_color": "C0DEED","followers_count": 48,"profile_image_url": "http://a1.twimg.com/profile_images/455128973/gCsVUnofNqqyd6tdOGevROvko1_500_normal.jpg","listed_count": 0,"profile_background_image_url": "http://a3.twimg.com/a/1300479984/images/themes/theme1/bg.png","description": "watcha doin in my waters?","screen_name": "OldGREG85","default_profile": true,"verified": false,"time_zone": "Hawaii","profile_text_color": "333333","is_translator: false,"profile_sidebar_fill_color": "DDEEF6","location": "Texas","id_str": "80177619","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 81,"protected": false,"favourites_count": 0,"created_at": "Tue Oct 06 01:13:17 +0000 2009","profile_link_color": "0084B4","name": "GG","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 80177619,"contributors_enabled": false,"following": null,"utc_offset": -36000},"id": 54691802283900930,"coordinates": null,"geo": null}`,
+		valid: false,
+	},
+	{
+		// "hashtags": [{"text": "PGP","indices": [130,134]}},
+		json:  `{"text": "RT @PostGradProblem: In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during ...","truncated": true,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54691802283900928","entities": {"user_mentions": [{"indices": [3,19],"screen_name": "PostGradProblem","id_str": "271572434","name": "PostGradProblems","id": 271572434}],"urls": [ ],"hashtags": [ ]},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 23:48:36 +0000 2011","retweeted_status": {"text": "In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during company time. #PGP","truncated": false,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54640519019642881","entities": {"user_mentions": [ ],"urls": [ ],"hashtags": [{"text": "PGP","indices": [130,134]}},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 20:24:49 +0000 2011","user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 31,"profile_background_color": "C0DEED","followers_count": 3066,"profile_image_url": "http://a2.twimg.com/profile_images/1285770264/PGP_normal.jpg","listed_count": 6,"profile_background_image_url": "http://a3.twimg.com/a/1301071706/images/themes/theme1/bg.png","description": "","screen_name": "PostGradProblem","default_profile": true,"verified": false,"time_zone": null,"profile_text_color": "333333","is_translator": false,"profile_sidebar_fill_color": "DDEEF6","location": "","id_str": "271572434","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 21,"protected": false,"favourites_count": 0,"created_at": "Thu Mar 24 19:45:44 +0000 2011","profile_link_color": "0084B4","name": "PostGradProblems","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 271572434,"contributors_enabled": false,"following": null,"utc_offset": null},"id": 54640519019642880,"coordinates": null,"geo": null},"user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 351,"profile_background_color": "C0DEED","followers_count": 48,"profile_image_url": "http://a1.twimg.com/profile_images/455128973/gCsVUnofNqqyd6tdOGevROvko1_500_normal.jpg","listed_count": 0,"profile_background_image_url": "http://a3.twimg.com/a/1300479984/images/themes/theme1/bg.png","description": "watcha doin in my waters?","screen_name": "OldGREG85","default_profile": true,"verified": false,"time_zone": "Hawaii","profile_text_color": "333333","is_translator": false,"profile_sidebar_fill_color": "DDEEF6","location": "Texas","id_str": "80177619","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 81,"protected": false,"favourites_count": 0,"created_at": "Tue Oct 06 01:13:17 +0000 2009","profile_link_color": "0084B4","name": "GG","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 80177619,"contributors_enabled": false,"following": null,"utc_offset": -36000},"id": 54691802283900930,"coordinates": null,"geo": null}`,
+		valid: false,
+	},
+	{
+		json:  `{"bad-key":falre}`,
+		valid: false,
+	},
+	{
+		json:  `{"boolean":true}`,
+		valid: true,
+	},
+	{
+		json:  `{"nums":773,"type":"integer"}`,
+		valid: true,
+	},
+	{
+		json:  `{"empty":null, "foo":["bar", "baz", 83, null]}`,
+		valid: true,
+	},
+	{
+		json:  `this is in no way json`,
+		valid: false,
+	},
+	{
+		json:    `["foo", false, [1, 2, 3], {"key":"value", "bool":false, "empty":null}, "bar"]`,
+		valid:   true,
+		isArray: true,
+	},
+	{
+		json:    `["simple", "array"]`,
+		valid:   true,
+		isArray: true,
+	},
+	{
+		json:    `["invalid", "array]`,
+		valid:   false,
+		isArray: true,
+	},
+	{
+		json:    `[33, false, 77, random, "array"]`,
+		valid:   false,
+		isArray: true,
+	},
+	{
+		json:  `{}`,
+		valid: true,
+	},
+	{
+		json:    `[]`,
+		valid:   true,
+		isArray: true,
+	},
+	{
+		json:  ``,
+		valid: false,
+	},
+	{
+		json:  `"just a string"`,
+		valid: false,
+	},
+}
+
+func TestIsJson(t *testing.T) {
+	for _, jt := range jsonTests {
+		if !jt.isArray && IsJson([]byte(jt.json)) != jt.valid {
+			t.Error("IsJson() failed")
+			t.Log("Json: ", jt.json)
+			t.Log("Expected: ", jt.valid)
+		}
+		if IsJsonFast([]byte(jt.json)) != jt.valid {
+			t.Error("IsJsonFast() failed")
+			t.Log("Json: ", jt.json)
+			t.Log("Expected: ", jt.valid)
+		}
+	}
+}


### PR DESCRIPTION
Create a recursive function `IsJsonFast()` based on `jsonparser` to check if a `[]byte` is valid JSON. Experimental but seems to work well and is much faster and smaller footprint than `IsJson()` using reflection.

```
BenchmarkIsJson-4                 100000             23492 ns/op            3688 B/op         66 allocs/op
BenchmarkIsJsonFast-4             300000              5364 ns/op             529 B/op         10 allocs/op
```