### PR TITLE
3.0.0 from RC to Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+glide.lock
 
 # Folders
 _obj
@@ -23,5 +24,6 @@ _testmain.go
 *.test
 *.prof
 bin/
+vendor/
 
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ before_install:
 - go get github.com/mattn/goveralls
 - go get golang.org/x/tools/cmd/cover
 - go get github.com/mitchellh/gox
+- go get github.com/Masterminds/glide
+- glide up
 script:
 - "$HOME/gopath/bin/goveralls -service=travis-ci"
 - gox -output "bin/{{.Dir}}_{{.OS}}_{{.Arch}}" ./...

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ pull requests for new transform types so that they can be incorporated into the 
 but understand sometimes time-constraints or licensing issues prevent this. See the API documentation
 for details on how to write and register custom transforms.
 
+Due to performance considerations, Kazaam does not fully validate that input data is valid JSON. The
+`IsJson()` function is provided for convenience if this functionality is needed, it may significantly slow
+down use of Kazaam.
+
 ## Specification Support
 Kazaam currently supports the following transforms:
 - shift

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
 package: github.com/qntfy/kazaam
 import:
-- package: github.com/bitly/go-simplejson
-  version: ^0.5.0
+- package: github.com/buger/jsonparser
+  version: bb14bb6c38f6cf1706ef55278891d184b6a51b0e

--- a/kazaam.go
+++ b/kazaam.go
@@ -2,25 +2,26 @@
 package kazaam
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/bitly/go-simplejson"
+	"github.com/buger/jsonparser"
 	"github.com/qntfy/kazaam/transform"
 )
 
 // TransformFunc defines the contract that any Transform function implementation
 // must abide by. The transform's first argument is a `kazaam.Spec` object that
 // contains any configuration necessary for the transform. The second argument
-// is a `simplejson.Json` object that contains the data to be transformed.
+// is a `[]byte` object that contains the data to be transformed.
 //
-// The data object passed in should be modified in-place. Where that is not
-// possible, a new `simplejson.Json` object should be created and the pointer
-// updated. The function should return an error if necessary.
+// The data object passed in should be modified in-place and returned. Where
+// that is not possible, a new `[]byte` object should be created and returned.
+// The function should return an error if necessary.
 // Transforms should strive to fail gracefully whenever possible.
-type TransformFunc func(spec *transform.Config, data *simplejson.Json) error
+type TransformFunc func(spec *transform.Config, data []byte) ([]byte, error)
 
 var validSpecTypes map[string]TransformFunc
 
@@ -165,76 +166,96 @@ func transformErrorType(err error) error {
 	}
 }
 
-// Transform takes the *simplejson.Json `data`, transforms it according
-// to the loaded spec, and returns the modified *simplejson.Json object.
-func (k *Kazaam) Transform(data *simplejson.Json) (*simplejson.Json, error) {
-	d := simplejson.New()
-	d.SetPath(nil, data.Interface())
-	err := k.TransformInPlace(d)
+// Transform makes a copy of the byte slice `data`, transforms it according
+// to the loaded spec, and returns the new, modified byte slice.
+func (k *Kazaam) Transform(data []byte) ([]byte, error) {
+	d := make([]byte, len(data))
+	copy(d, data)
+	d, err := k.TransformInPlace(d)
 	return d, err
 }
 
-// TransformInPlace takes the *simplejson.Json `data`, transforms it according
-// to the loaded spec, and modifies the *simplejson.Json object.
+// TransformInPlace takes the byte slice `data`, transforms it according
+// to the loaded spec, and modifies the byte slice in place.
 //
 // Note: this is a destructive operation: the transformation is done in place.
-// You must perform a deep copy of the data prior to calling Transform if
+// You must perform a deep copy of the data prior to calling TransformInPlace if
 // the original JSON object must be retained.
-func (k *Kazaam) TransformInPlace(data *simplejson.Json) error {
+func (k *Kazaam) TransformInPlace(data []byte) ([]byte, error) {
+	if k == nil || k.specJSON == nil {
+		return data, &Error{ErrMsg: "Kazaam not properly initialized", ErrType: SpecError}
+	}
+	if len(data) == 0 {
+		return data, nil
+	}
+
 	var err error
 	for _, specObj := range k.specJSON {
 		if specObj.Config != nil && specObj.Over != nil {
-			dataList := data.GetPath(strings.Split(*specObj.Over, ".")...).MustArray()
-
-			var transformedDataList []interface{}
-			for _, x := range dataList {
-				jsonValue := simplejson.New()
-				jsonValue.SetPath(nil, x)
-				intErr := k.getTransform(&specObj)(specObj.Config, jsonValue)
-				if intErr != nil {
-					return transformErrorType(err)
-				}
-				transformedDataList = append(transformedDataList, jsonValue.Interface())
+			var transformedDataList [][]byte
+			_, err = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+				transformedDataList = append(transformedDataList, value)
+			}, strings.Split(*specObj.Over, ".")...)
+			if err != nil {
+				return data, transformErrorType(err)
 			}
-			data.SetPath(strings.Split(*specObj.Over, "."), transformedDataList)
+			for i, value := range transformedDataList {
+				x := make([]byte, len(value))
+				copy(x, value)
+				x, intErr := k.getTransform(&specObj)(specObj.Config, x)
+				if intErr != nil {
+					return data, transformErrorType(err)
+				}
+				transformedDataList[i] = x
+			}
+			// copy into raw []byte format and return
+			var buffer bytes.Buffer
+			buffer.WriteByte('[')
+			for i := 0; i < len(transformedDataList)-1; i++ {
+				buffer.Write(transformedDataList[i])
+				buffer.WriteByte(',')
+			}
+			if len(transformedDataList) > 0 {
+				buffer.Write(transformedDataList[len(transformedDataList)-1])
+			}
+			buffer.WriteByte(']')
+			data, err = jsonparser.Set(data, buffer.Bytes(), strings.Split(*specObj.Over, ".")...)
+			if err != nil {
+				return data, transformErrorType(err)
+			}
 
 		} else {
-			err = k.getTransform(&specObj)(specObj.Config, data)
+			data, err = k.getTransform(&specObj)(specObj.Config, data)
 			if err != nil {
-				return transformErrorType(err)
+				return data, transformErrorType(err)
 			}
 		}
 	}
-	return transformErrorType(err)
+	return data, transformErrorType(err)
 }
 
 // TransformJSONStringToString loads the JSON string `data`, transforms
 // it as per the spec, and returns the transformed JSON string.
 func (k *Kazaam) TransformJSONStringToString(data string) (string, error) {
-	// read in the arbitrary input data
-	d, err := simplejson.NewJson([]byte(data))
+	d, err := k.TransformJSONString(data)
 	if err != nil {
 		return "", err
 	}
-	err = k.TransformInPlace(d)
-	if err != nil {
-		return "", err
-	}
-	jsonString, _ := d.MarshalJSON()
-	return string(jsonString), nil
+	return string(d), nil
 }
 
 // TransformJSONString loads the JSON string, transforms it as per the
-// spec, and returns a pointer to a transformed simplejson.Json.
+// spec, and returns a pointer to a transformed []byte.
 //
 // This function is especially useful when one may need to extract
 // multiple fields from the transformed JSON.
-func (k *Kazaam) TransformJSONString(data string) (*simplejson.Json, error) {
+func (k *Kazaam) TransformJSONString(data string) ([]byte, error) {
 	// read in the arbitrary input data
-	d, err := simplejson.NewJson([]byte(data))
+	d := make([]byte, len(data))
+	copy(d, []byte(data))
+	d, err := k.TransformInPlace(d)
 	if err != nil {
-		return nil, err
+		return []byte{}, err
 	}
-	k.TransformInPlace(d)
-	return d, nil
+	return d, err
 }

--- a/kazaam_benchmarks_test.go
+++ b/kazaam_benchmarks_test.go
@@ -10,6 +10,10 @@ const (
 	benchmarkJSON = `{"topKeyA": {"arrayKey": [{"foo": 0}, {"foo": 1}, {"foo": 1}, {"foo": 2}], "notArrayKey": "bar", "deepArrayKey": [{"key0":["val0", "val1"]}]}, "topKeyB":{"nextKeyB": "valueB"}}`
 )
 
+var (
+	benchmarkSlice = []byte(benchmarkJSON)
+)
+
 // Just for emulating field access, so it will not throw "evaluated but not
 // used." Borrowed from:
 // https://github.com/buger/jsonparser/blob/master/benchmark/benchmark_small_payload_test.go
@@ -262,6 +266,18 @@ func BenchmarkExtractTransformOnly(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		kazaamOut, _ := transform.TransformJSONStringToString(benchmarkJSON)
 		nothing(kazaamOut)
+	}
+
+}
+
+func BenchmarkIsJsonFast(b *testing.B) {
+	b.ReportAllocs()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		val := kazaam.IsJsonFast(benchmarkSlice)
+		nothing(val)
 	}
 
 }

--- a/kazaam_int_test.go
+++ b/kazaam_int_test.go
@@ -3,7 +3,7 @@ package kazaam_test
 import (
 	"testing"
 
-	simplejson "github.com/bitly/go-simplejson"
+	"github.com/buger/jsonparser"
 	"github.com/qntfy/kazaam"
 	"github.com/qntfy/kazaam/transform"
 )
@@ -35,7 +35,7 @@ func TestKazaamBadJSONSpecification(t *testing.T) {
 
 func TestKazaamBadJSONTransform(t *testing.T) {
 	kazaamTransform, _ := kazaam.NewKazaam(`[{"operation": "shift,"spec": {"data": ["$"]}}]`)
-	_, err := kazaamTransform.TransformJSONString(`{"data"}`)
+	_, err := kazaamTransform.TransformJSONString(`{"data":"foo"}`)
 	if err == nil {
 		t.Error("Specification JSON is invalid and should throw an error")
 		t.FailNow()
@@ -60,7 +60,7 @@ func TestKazaamBadJSONTransformBadOperation(t *testing.T) {
 
 func TestKazaamMultipleTransforms(t *testing.T) {
 	jsonOut1 := `{"Rating":3,"example":{"old":{"value":3}}}`
-	jsonOut2 := `{"Range":5,"rating":{"example":{"value":3},"primary":{"value":3}}}`
+	jsonOut2 := `{"rating":{"example":{"value":3},"primary":{"value":3}},"Range":5}`
 	spec1 := `[{"operation": "shift", "spec": {"Rating": "rating.primary.value", "example.old": "rating.example"}}]`
 	spec2 := `[{"operation": "default", "spec": {"Range": 5}}]`
 
@@ -86,7 +86,7 @@ func TestKazaamMultipleTransforms(t *testing.T) {
 }
 
 func TestKazaamMultipleTransformsRequire(t *testing.T) {
-	jsonOut2 := `{"Range":5,"rating":{"example":{"value":3},"primary":{"value":3}}}`
+	jsonOut2 := `{"rating":{"example":{"value":3},"primary":{"value":3}},"Range":5}`
 	spec1 := `[{"operation": "shift", "spec": {"Rating": "rating.primary.no_value", "example.old": "rating.example"}, "require": true}]`
 	spec2 := `[{"operation": "default", "spec": {"Range": 5}, "require": true}]`
 
@@ -132,12 +132,16 @@ func TestKazaamCoalesceTransformAndShift(t *testing.T) {
 		"operation": "shift",
 		"spec": {"rating.foo": "foo", "rating.example.value": "rating.primary.value"}
 	}]`
-	jsonOut := `{"rating":{"example":{"value":3},"foo":{"value":3}}}`
+
+	// for some reason, keys are inserted in different order on different runs locally and in CI
+	// so without the alt we get sporadic failures.
+	jsonOut := `{"rating":{"foo":{"value":3},"example":{"value":3}}}`
+	altJsonOut := `{"rating":{"example":{"value":3},"foo":{"value":3}}}`
 
 	kazaamTransform, _ := kazaam.NewKazaam(spec)
 	kazaamOut, _ := kazaamTransform.TransformJSONStringToString(testJSONInput)
 
-	if kazaamOut != jsonOut {
+	if kazaamOut != jsonOut && kazaamOut != altJsonOut {
 		t.Error("Transformed data does not match expectation.")
 		t.Log("Expected: ", jsonOut)
 		t.Log("Actual:   ", kazaamOut)
@@ -147,11 +151,19 @@ func TestKazaamCoalesceTransformAndShift(t *testing.T) {
 
 func TestShiftWithOverAndWildcard(t *testing.T) {
 	spec := `[{"operation": "shift","spec": {"docs": "documents[*]"}}, {"operation": "shift",  "spec": {"data": "norm.text"}, "over":"docs"}]`
-	jsonIn := `{"documents":[{"norm": {"text": "String 1"}}, {"norm": {"text": "String 2"}}]}`
+	jsonIn := `{"documents":[{"norm":{"text":"String 1"}},{"norm":{"text":"String 2"}}]}`
 	jsonOut := `{"docs":[{"data":"String 1"},{"data":"String 2"}]}`
 
 	kazaamTransform, _ := kazaam.NewKazaam(spec)
-	kazaamOut, _ := kazaamTransform.TransformJSONStringToString(jsonIn)
+	kazaamOut, err := kazaamTransform.TransformJSONStringToString(jsonIn)
+
+	if err != nil {
+		t.Error("Transform produced error.")
+		t.Log("Error: ", err.Error())
+		t.Log("Expected: ", jsonOut)
+		t.Log("Actual:   ", kazaamOut)
+		t.FailNow()
+	}
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
@@ -170,7 +182,7 @@ func TestKazaamTransformMultiOpWithOver(t *testing.T) {
 		"operation": "shift",
 		"spec": {"urls": "a[*].url" }
 	}]`
-	jsonIn := `{"a":[{"foo": 0}, {"foo": 1}, {"foo": 2}]}`
+	jsonIn := `{"a":[{"foo":0},{"foo":1},{"foo":2}]}`
 	jsonOut := `{"urls":["0:KEY","1:KEY","2:KEY"]}`
 
 	kazaamTransform, _ := kazaam.NewKazaam(spec)
@@ -185,8 +197,8 @@ func TestKazaamTransformMultiOpWithOver(t *testing.T) {
 }
 
 func TestShiftWithOver(t *testing.T) {
-	jsonIn := `{"rating": {"primary": [{"value": 3}, {"value": 5}], "example": {"value": 3}}}`
-	jsonOut := `{"rating":{"example":{"value":3},"primary":[{"new_value":3},{"new_value":5}]}}`
+	jsonIn := `{"rating":{"primary":[{"value":3},{"value":5}],"example":{"value":3}}}`
+	jsonOut := `{"rating":{"primary":[{"new_value":3},{"new_value":5}],"example":{"value":3}}}`
 	spec := `[{"operation": "shift", "over": "rating.primary", "spec": {"new_value":"value"}}]`
 
 	kazaamTransform, _ := kazaam.NewKazaam(spec)
@@ -201,7 +213,7 @@ func TestShiftWithOver(t *testing.T) {
 }
 
 func TestShiftAndGet(t *testing.T) {
-	jsonOut := 3
+	jsonOut := "3"
 	spec := `[{"operation": "shift","spec": {"Rating": "rating.primary.value","example.old": "rating.example"}}]`
 
 	kazaamTransform, _ := kazaam.NewKazaam(spec)
@@ -210,15 +222,15 @@ func TestShiftAndGet(t *testing.T) {
 		t.Error("Failed to parse JSON message before transformation")
 		t.FailNow()
 	}
-	kazaamOut, found := transformed.CheckGet("Rating")
-	if !found {
+	kazaamOut, _, _, err := jsonparser.Get(transformed, "Rating")
+	if err != nil {
 		t.Log("Requested key not found")
 	}
 
-	if kazaamOut.MustInt() != jsonOut {
+	if string(kazaamOut) != jsonOut {
 		t.Error("Transformed data does not match expectation.")
 		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut.MustInt())
+		t.Log("Actual:   ", string(kazaamOut))
 		t.FailNow()
 	}
 }
@@ -245,37 +257,41 @@ func TestMissingRequiredField(t *testing.T) {
 func TestKazaamNoModify(t *testing.T) {
 	spec := `[{"operation": "shift","spec": {"Rating": "rating.primary.value","example.old": "rating.example"}}]`
 	msgOut := `{"Rating":3,"example":{"old":{"value":3}}}`
+	altMsgOut := `{"example":{"old":{"value":3}},"Rating":3}`
 	tf, _ := kazaam.NewKazaam(spec)
-	data, _ := simplejson.NewJson([]byte(testJSONInput))
-	k, _ := tf.Transform(data)
+	data := []byte(testJSONInput)
+	jsonOut, _ := tf.Transform(data)
 
-	jsonOut, _ := k.MarshalJSON()
 	jsonOutStr := string(jsonOut)
 
-	if jsonOutStr != msgOut || jsonOutStr == testJSONInput {
+	if !(jsonOutStr == msgOut || jsonOutStr == altMsgOut) || jsonOutStr == testJSONInput {
 		t.Error("Unexpected transformation result")
 		t.Error("Actual:", jsonOutStr)
 		t.Error("Expected:", msgOut)
 	}
 
-	b, _ := data.MarshalJSON()
-	if string(b) != testJSONInput {
+	if string(data) != testJSONInput {
 		t.Error("Unexpected modification")
-		t.Error("Actual:", string(b))
+		t.Error("Actual:", string(data))
 		t.Error("Expected:", testJSONInput)
 	}
 }
 
 func TestConfigdKazaamGet3rdPartyTransform(t *testing.T) {
 	kc := kazaam.NewDefaultConfig()
-	kc.RegisterTransform("3rd-party", func(spec *transform.Config, data *simplejson.Json) error {
-		data.Set("doesnt-exist", "does-exist")
-		return nil
+	kc.RegisterTransform("3rd-party", func(spec *transform.Config, data []byte) ([]byte, error) {
+		data, _ = jsonparser.Set(data, []byte(`"does-exist"`), "doesnt-exist")
+		return data, nil
 	})
+	msgOut := `{"test":"data","doesnt-exist":"does-exist"}`
+
 	k, _ := kazaam.New(`[{"operation": "3rd-party"}]`, kc)
-	kazaamOut, _ := k.TransformJSONStringToString(`{"test": "data"}`)
-	if kazaamOut != `{"doesnt-exist":"does-exist","test":"data"}` {
+	kazaamOut, _ := k.TransformJSONStringToString(`{"test":"data"}`)
+	if kazaamOut != msgOut {
 		t.Error("Unexpected transform output")
+		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected: ", msgOut)
+
 	}
 }
 
@@ -292,7 +308,7 @@ func TestKazaamTransformThreeOpWithOver(t *testing.T) {
 		"operation": "shift",
 		"spec": {"urls": "a[*].url" }
 	}]`
-	jsonIn := `{"key":{"array1":[{"array2":[{"foo": 0}, {"foo": 1}, {"foo": 2}]}]}}`
+	jsonIn := `{"key":{"array1":[{"array2":[{"foo":0},{"foo":1},{"foo":2}]}]}}`
 	jsonOut := `{"urls":["0:KEY","1:KEY","2:KEY"]}`
 
 	kazaamTransform, _ := kazaam.NewKazaam(spec)

--- a/kazaam_test.go
+++ b/kazaam_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	simplejson "github.com/bitly/go-simplejson"
+	"github.com/buger/jsonparser"
 	"github.com/qntfy/kazaam/transform"
 )
 
@@ -18,9 +18,9 @@ func TestDefaultKazaamGetUnknownTransform(t *testing.T) {
 
 func TestKazaamWithRegisteredTransform(t *testing.T) {
 	kc := NewDefaultConfig()
-	kc.RegisterTransform("3rd-party", func(spec *transform.Config, data *simplejson.Json) error {
-		data.Set("doesnt-exist", "does-exist")
-		return nil
+	kc.RegisterTransform("3rd-party", func(spec *transform.Config, data []byte) ([]byte, error) {
+		data, _ = jsonparser.Set(data, []byte("doesnt-exist"), "does-exist")
+		return data, nil
 	})
 	_, err := New(`[{"operation": "3rd-party"}]`, kc)
 	if err != nil {
@@ -90,19 +90,22 @@ func ExampleConfig_RegisterTransform() {
 
 	// register the new custom transform called "copy" which supports copying the
 	// value of a top-level key to another top-level key
-	kc.RegisterTransform("copy", func(spec *transform.Config, data *simplejson.Json) error {
+	kc.RegisterTransform("copy", func(spec *transform.Config, data []byte) ([]byte, error) {
 		// the internal `Spec` will contain a mapping of source and target keys
 		for targetField, sourceFieldInt := range *spec.Spec {
 			sourceField := sourceFieldInt.(string)
-			data.Set(targetField, data.Get(sourceField).Interface())
+			// Note: jsonparser.Get() strips quotes from returned strings, so a real
+			// transform would need handling for that. We use a Number below for simplicity.
+			result, _, _, _ := jsonparser.Get(data, sourceField)
+			data, _ = jsonparser.Set(data, result, targetField)
 		}
-		return nil
+		return data, nil
 	})
 
 	k, _ := New(`[{"operation": "copy", "spec": {"output": "input"}}]`, kc)
-	kazaamOut, _ := k.TransformJSONStringToString(`{"input":"input value"}`)
+	kazaamOut, _ := k.TransformJSONStringToString(`{"input":72}`)
 
 	fmt.Println(kazaamOut)
 	// Output:
-	// {"input":"input value","output":"input value"}
+	// {"input":72,"output":72}
 }

--- a/transform/coalesce.go
+++ b/transform/coalesce.go
@@ -1,16 +1,17 @@
 package transform
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
-	simplejson "github.com/bitly/go-simplejson"
+	"github.com/buger/jsonparser"
 )
 
-// Coalesce checks multiple keys and returns the first matching key found.
-func Coalesce(spec *Config, data *simplejson.Json) error {
+// Coalesce checks multiple keys and returns the first matching key found in raw []byte.
+func Coalesce(spec *Config, data []byte) ([]byte, error) {
 	if spec.Require == true {
-		return SpecError("Invalid spec. Coalesce does not support \"require\"")
+		return nil, SpecError("Invalid spec. Coalesce does not support \"require\"")
 	}
 	for k, v := range *spec.Spec {
 		outPath := strings.Split(k, ".")
@@ -23,29 +24,33 @@ func Coalesce(spec *Config, data *simplejson.Json) error {
 			for _, vItem := range v.([]interface{}) {
 				vItemStr, found := vItem.(string)
 				if !found {
-					return ParseError(fmt.Sprintf("Warn: Unable to coerce element to json string: %v", vItem))
+					return nil, ParseError(fmt.Sprintf("Warn: Unable to coerce element to json string: %v", vItem))
 				}
 				keyList = append(keyList, vItemStr)
 			}
 		default:
-			return ParseError(fmt.Sprintf("Warn: Expected list in message for key: %s", k))
+			return nil, ParseError(fmt.Sprintf("Warn: Expected list in message for key: %s", k))
 		}
 
 		// iterate over keys to evaluate
 		for _, v := range keyList {
-			var dataForV *simplejson.Json
+			var dataForV []byte
 			var err error
 
 			// grab the data
-			dataForV, err = getJSONPath(data, v, false)
+			dataForV, err = getJSONRaw(data, v, false)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			if dataForV.Interface() != nil {
-				data.SetPath(outPath, dataForV.Interface())
+			if bytes.Compare(dataForV, []byte("null")) != 0 {
+				data, err = jsonparser.Set(data, dataForV, outPath...)
+				if err != nil {
+					return nil, err
+				}
 				break
 			}
 		}
 	}
-	return nil
+	return data, nil
+
 }

--- a/transform/coalesce_test.go
+++ b/transform/coalesce_test.go
@@ -4,15 +4,15 @@ import "testing"
 
 func TestCoalesce(t *testing.T) {
 	spec := `{"foo": ["rating.foo", "rating.primary"]}`
-	jsonOut := `{"foo":{"value":3},"rating":{"example":{"value":3},"primary":{"value":3}}}`
+	jsonOut := `{"rating":{"example":{"value":3},"primary":{"value":3}},"foo":{"value":3}}`
 
 	cfg := getConfig(spec, false)
 	kazaamOut, _ := getTransformTestWrapper(Coalesce, cfg, testJSONInput)
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
@@ -31,15 +31,15 @@ func TestCoalesceWithRequire(t *testing.T) {
 
 func TestCoalesceWithMulti(t *testing.T) {
 	spec := `{"foo": ["rating.foo", "rating.primary"], "bar": ["rating.bar", "rating.example.value"]}`
-	jsonOut := `{"bar":3,"foo":{"value":3},"rating":{"example":{"value":3},"primary":{"value":3}}}`
+	jsonOut := `{"rating":{"example":{"value":3},"primary":{"value":3}},"foo":{"value":3},"bar":3}`
 
 	cfg := getConfig(spec, false)
 	kazaamOut, _ := getTransformTestWrapper(Coalesce, cfg, testJSONInput)
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
@@ -53,8 +53,8 @@ func TestCoalesceWithNotFound(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }

--- a/transform/concat.go
+++ b/transform/concat.go
@@ -1,22 +1,22 @@
 package transform
 
 import (
+	"bytes"
 	"fmt"
-	"reflect"
 	"strings"
 
-	simplejson "github.com/bitly/go-simplejson"
+	"github.com/buger/jsonparser"
 )
 
-// Concat combines any specified fields and literal strings into a single string value.
-func Concat(spec *Config, data *simplejson.Json) error {
+// Concat combines any specified fields and literal strings into a single string value with raw []byte.
+func Concat(spec *Config, data []byte) ([]byte, error) {
 	sourceList, sourceOk := (*spec.Spec)["sources"]
 	if !sourceOk {
-		return SpecError("Unable to get sources")
+		return nil, SpecError("Unable to get sources")
 	}
 	targetPath, targetOk := (*spec.Spec)["targetPath"]
 	if !targetOk {
-		return SpecError("Unable to get targetPath")
+		return nil, SpecError("Unable to get targetPath")
 	}
 	delimiter, delimOk := (*spec.Spec)["delim"]
 	if !delimOk {
@@ -34,37 +34,39 @@ func Concat(spec *Config, data *simplejson.Json) error {
 		if !ok {
 			path, ok := vItem.(map[string]interface{})["path"]
 			if ok {
-				valueNodePtr, err := getJSONPath(data, path.(string), spec.Require)
+				zed, err := getJSONRaw(data, path.(string), spec.Require)
 				switch {
 				case err != nil && spec.Require == true:
-					return RequireError("Path does not exist")
+					return nil, RequireError("Path does not exist")
 				case err != nil:
 					value = ""
 				default:
-					zed := (*valueNodePtr).Interface()
-					switch zed.(type) {
-					case []interface{}:
+					switch zed[0] {
+					case '[':
 						temp := ""
-						for _, item := range zed.([]interface{}) {
-							if item != nil {
-								temp += reflect.ValueOf(item).String()
+						jsonparser.ArrayEach(zed, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+							if bytes.Compare(value, []byte("null")) != 0 {
+								temp += string(value)
 							}
-						}
+						})
 						value = temp
+					case '"':
+						value = string(zed[1 : len(zed)-1])
 					default:
-						value = reflect.ValueOf(zed).String()
+						value = string(zed)
 					}
 				}
 			} else {
-				return SpecError(fmt.Sprintf("Error processing %v: must have either value or path specified", vItem))
+				return nil, SpecError(fmt.Sprintf("Error processing %v: must have either value or path specified", vItem))
 			}
 		}
 		outString += value.(string)
 
 		applyDelim = true
 	}
-
-	data.SetPath(strings.Split(targetPath.(string), "."), outString)
-
-	return nil
+	data, err := jsonparser.Set(data, bookend([]byte(outString), '"', '"'), strings.Split(targetPath.(string), ".")...)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
 }

--- a/transform/concat_test.go
+++ b/transform/concat_test.go
@@ -4,23 +4,23 @@ import "testing"
 
 func TestConcat(t *testing.T) {
 	spec := `{"sources": [{"value": "TEST"}, {"path": "a.timestamp"}], "targetPath": "a.output", "delim": "," }`
-	jsonIn := `{"a":{"timestamp": 1481305274}}`
-	jsonOut := `{"a":{"output":"TEST,1481305274","timestamp":1481305274}}`
+	jsonIn := `{"a":{"timestamp":1481305274}}`
+	jsonOut := `{"a":{"timestamp":1481305274,"output":"TEST,1481305274"}}`
 
 	cfg := getConfig(spec, false)
 	kazaamOut, _ := getTransformTestWrapper(Concat, cfg, jsonIn)
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
 
 func TestConcatWithRequireSources(t *testing.T) {
 	spec := `{"targetPath": "a.output", "delim": "," }`
-	jsonIn := `{"a":{"timestamp": 1481305274}}`
+	jsonIn := `{"a":{"timestamp":1481305274}}`
 
 	cfg := getConfig(spec, true)
 	_, err := getTransformTestWrapper(Concat, cfg, jsonIn)
@@ -33,7 +33,7 @@ func TestConcatWithRequireSources(t *testing.T) {
 
 func TestConcatWithRequireTargetPath(t *testing.T) {
 	spec := `{"sources": [{"value": "TEST"}, {"path": "a.timestamp"}], "delim": "," }`
-	jsonIn := `{"a":{"timestamp": 1481305274}}`
+	jsonIn := `{"a":{"timestamp":1481305274}}`
 
 	cfg := getConfig(spec, true)
 	_, err := getTransformTestWrapper(Concat, cfg, jsonIn)
@@ -46,7 +46,7 @@ func TestConcatWithRequireTargetPath(t *testing.T) {
 
 func TestConcatWithRequireSimplePath(t *testing.T) {
 	spec := `{"sources": [{"value": "TEST"}, {"path": "not.a.timestamp"}], "targetPath": "a.output", "delim": "," }`
-	jsonIn := `{"a":{"timestamp": 1481305274}}`
+	jsonIn := `{"a":{"timestamp":1481305274}}`
 
 	cfg := getConfig(spec, true)
 	_, err := getTransformTestWrapper(Concat, cfg, jsonIn)
@@ -59,7 +59,7 @@ func TestConcatWithRequireSimplePath(t *testing.T) {
 
 func TestConcatWithReplaceSimplePath(t *testing.T) {
 	spec := `{"sources": [{"value": "TEST"}, {"path": "a.timestamp"}], "targetPath": "a.timestamp", "delim": "," }`
-	jsonIn := `{"a":{"timestamp": 1481305274}}`
+	jsonIn := `{"a":{"timestamp":1481305274}}`
 	jsonOut := `{"a":{"timestamp":"TEST,1481305274"}}`
 
 	cfg := getConfig(spec, false)
@@ -67,31 +67,31 @@ func TestConcatWithReplaceSimplePath(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
 
 func TestConcatWithNoDelimiter(t *testing.T) {
 	spec := `{"sources": [{"value": "TEST"}, {"path": "a.timestamp"}], "targetPath": "a.output" }`
-	jsonIn := `{"a":{"timestamp": "1481305274"}}`
-	jsonOut := `{"a":{"output":"TEST1481305274","timestamp":"1481305274"}}`
+	jsonIn := `{"a":{"timestamp":"1481305274"}}`
+	jsonOut := `{"a":{"timestamp":"1481305274","output":"TEST1481305274"}}`
 
 	cfg := getConfig(spec, false)
 	kazaamOut, _ := getTransformTestWrapper(Concat, cfg, jsonIn)
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
 
 func TestConcatWithWildcard(t *testing.T) {
 	spec := `{"sources": [{"value": "TEST"}, {"path": "a[*].foo"}], "targetPath": "a.output", "delim": "," }`
-	jsonIn := `{"a":[{"foo": 0}, {"foo": 1}, {"foo": 1}, {"foo": 2}]}`
+	jsonIn := `{"a":[{"foo":0},{"foo":1},{"foo":1},{"foo":2}]}`
 	jsonOut := `{"a":{"output":"TEST,0112"}}`
 
 	cfg := getConfig(spec, false)
@@ -99,15 +99,15 @@ func TestConcatWithWildcard(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
 
 func TestConcatWithWildcardNested(t *testing.T) {
 	spec := `{"sources": [{"value": "TEST"}, {"path": "a.b[*].foo"}], "targetPath": "a.output", "delim": "," }`
-	jsonIn := `{"a": {"b": [{"foo": 0}, {"foo": 1}, {"foo": 1}, {"foo": 2}]}}`
+	jsonIn := `{"a":{"b":[{"foo":0},{"foo":1},{"foo":1},{"foo":2}]}}`
 	jsonOut := `{"a":{"b":[{"foo":0},{"foo":1},{"foo":1},{"foo":2}],"output":"TEST,0112"}}`
 
 	cfg := getConfig(spec, false)
@@ -115,15 +115,15 @@ func TestConcatWithWildcardNested(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
 
 func TestConcatWithBadPath(t *testing.T) {
 	spec := `{"sources": [{"value": "TEST"}, {"path": "a[*].bar"}], "targetPath": "a.output", "delim": "," }`
-	jsonIn := `{"a":[{"foo": 0}, {"foo": 1}, {"foo": 1}, {"foo": 2}]}`
+	jsonIn := `{"a":[{"foo":0},{"foo":1},{"foo":1},{"foo":2}]}`
 	jsonOut := `{"a":{"output":"TEST,"}}`
 
 	cfg := getConfig(spec, false)
@@ -131,8 +131,8 @@ func TestConcatWithBadPath(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
@@ -140,7 +140,7 @@ func TestConcatWithBadPath(t *testing.T) {
 func TestConcatWithBadSpec(t *testing.T) {
 	// Bad spec - "Path" should be "path"
 	spec := `{"sources": [{"value": "TEST"}, {"Path": "a[*].bar"}], "targetPath": "a.timestamp", "delim": "," }`
-	jsonIn := `{"a":[{"foo": 0}, {"foo": 1}, {"foo": 1}, {"foo": 2}]}`
+	jsonIn := `{"a":[{"foo":0},{"foo":1},{"foo":1},{"foo":2}]}`
 	// bad path should cause the result to be blank
 	jsonOut := ""
 
@@ -149,15 +149,15 @@ func TestConcatWithBadSpec(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
 
 func TestConcatWithMultiMulti(t *testing.T) {
 	spec := `{"sources": [{"value": "BEGIN"}, {"path": "a[*].foo"}, {"value": "END"}], "targetPath": "a.output", "delim": "," }`
-	jsonIn := `{"a":[{"foo": 0}, {"foo": 1}, {"foo": 1}, {"foo": 2}]}`
+	jsonIn := `{"a":[{"foo":0},{"foo":1},{"foo":1},{"foo":2}]}`
 	jsonOut := `{"a":{"output":"BEGIN,0112,END"}}`
 
 	cfg := getConfig(spec, false)
@@ -165,24 +165,24 @@ func TestConcatWithMultiMulti(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
 
 func TestConcatWithLargeNumbers(t *testing.T) {
 	spec := `{"sources": [{"path": "a.timestamp"}], "targetPath": "a.output" }`
-	jsonIn := `{"a":{"timestamp": 1481305274100000000000000000000}}`
-	jsonOut := `{"a":{"output":"1481305274100000000000000000000","timestamp":1481305274100000000000000000000}}`
+	jsonIn := `{"a":{"timestamp":1481305274100000000000000000000}}`
+	jsonOut := `{"a":{"timestamp":1481305274100000000000000000000,"output":"1481305274100000000000000000000"}}`
 
 	cfg := getConfig(spec, false)
 	kazaamOut, _ := getTransformTestWrapper(Concat, cfg, jsonIn)
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }

--- a/transform/default.go
+++ b/transform/default.go
@@ -1,15 +1,25 @@
 package transform
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 
-	simplejson "github.com/bitly/go-simplejson"
+	"github.com/buger/jsonparser"
 )
 
-// Default sets specific value(s) in output json.
-func Default(spec *Config, data *simplejson.Json) error {
+// Default sets specific value(s) in output json in raw []byte.
+func Default(spec *Config, data []byte) ([]byte, error) {
 	for k, v := range *spec.Spec {
-		data.SetPath(strings.Split(k, "."), v)
+		var err error
+		dataForV, err := json.Marshal(v)
+		if err != nil {
+			return nil, ParseError(fmt.Sprintf("Warn: Unable to coerce element to json string: %v", v))
+		}
+		data, err = jsonparser.Set(data, dataForV, strings.Split(k, ".")...)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return nil
+	return data, nil
 }

--- a/transform/default_test.go
+++ b/transform/default_test.go
@@ -4,15 +4,20 @@ import "testing"
 
 func TestDefault(t *testing.T) {
 	spec := `{"Range": 5}`
-	jsonOut := `{"Range":5,"rating":{"example":{"value":3},"primary":{"value":3}}}`
+	jsonOut := `{"rating":{"example":{"value":3},"primary":{"value":3}},"Range":5}`
 
 	cfg := getConfig(spec, false)
-	kazaamOut, _ := getTransformTestWrapper(Default, cfg, testJSONInput)
+	kazaamOut, err := getTransformTestWrapper(Default, cfg, testJSONInput)
 
+	if err != nil {
+		t.Error("Error in transform (simplejson).")
+		t.Log("Error: ", err.Error())
+		t.FailNow()
+	}
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }

--- a/transform/extract.go
+++ b/transform/extract.go
@@ -1,17 +1,14 @@
 package transform
 
-import simplejson "github.com/bitly/go-simplejson"
-
-// Extract returns the specified path as the top-level object.
-func Extract(spec *Config, data *simplejson.Json) error {
+// Extract returns the specified path as the top-level object in raw []byte.
+func Extract(spec *Config, data []byte) ([]byte, error) {
 	outPath, ok := (*spec.Spec)["path"]
 	if !ok {
-		return SpecError("Unable to get path")
+		return nil, SpecError("Unable to get path")
 	}
-	tmp, err := getJSONPath(data, outPath.(string), spec.Require)
+	result, err := getJSONRaw(data, outPath.(string), spec.Require)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	*data = *tmp
-	return nil
+	return result, nil
 }

--- a/transform/extract_test.go
+++ b/transform/extract_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestExtract(t *testing.T) {
 	spec := `{"path": "_source"}`
-	jsonIn := `{"data": {"id": true}, "_source": {"a": 123, "b": "str", "c": null, "d": true}}`
+	jsonIn := `{"data":{"id":true},"_source":{"a":123,"b":"str","c":null,"d":true}}`
 	jsonOut := `{"a":123,"b":"str","c":null,"d":true}`
 
 	cfg := getConfig(spec, false)
@@ -12,8 +12,8 @@ func TestExtract(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
@@ -41,8 +41,8 @@ func TestExtractWithBadPath(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }

--- a/transform/pass.go
+++ b/transform/pass.go
@@ -1,9 +1,7 @@
 package transform
 
-import simplejson "github.com/bitly/go-simplejson"
-
 // Pass performs no manipulation of the passed-in data. It is useful
 // for testing/default behavior.
-func Pass(spec *Config, data *simplejson.Json) error {
-	return nil
+func Pass(spec *Config, data []byte) ([]byte, error) {
+	return data, nil
 }

--- a/transform/shift.go
+++ b/transform/shift.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	simplejson "github.com/bitly/go-simplejson"
+	"github.com/buger/jsonparser"
 )
 
-// Shift moves values from one provided json path to another.
-func Shift(spec *Config, data *simplejson.Json) error {
-	outData := simplejson.New()
+// Shift moves values from one provided json path to another in raw []byte.
+func Shift(spec *Config, data []byte) ([]byte, error) {
+	outData := []byte(`{}`)
 	for k, v := range *spec.Spec {
 		array := true
 		outPath := strings.Split(k, ".")
@@ -25,39 +25,51 @@ func Shift(spec *Config, data *simplejson.Json) error {
 			for _, vItem := range v.([]interface{}) {
 				vItemStr, found := vItem.(string)
 				if !found {
-					return ParseError(fmt.Sprintf("Warn: Unable to coerce element to json string: %v", vItem))
+					return nil, ParseError(fmt.Sprintf("Warn: Unable to coerce element to json string: %v", vItem))
 				}
 				keyList = append(keyList, vItemStr)
 			}
 		default:
-			return ParseError(fmt.Sprintf("Warn: Unknown type in message for key: %s", k))
+			return nil, ParseError(fmt.Sprintf("Warn: Unknown type in message for key: %s", k))
 		}
 
 		// iterate over keys to evaluate
+		// Note: this could be sped up significantly (especially for large shift transforms)
+		// by using `jsonparser.EachKey()` to iterate through data once and pick up all the
+		// needed underlying data. It would be a non-trivial update since you'd have to make
+		// recursive calls and keep track of all the key paths at each level.
+		// Currently we iterate at worst once per key in spec, with a better design it would be once
+		// per spec.
 		for _, v := range keyList {
-			var dataForV *simplejson.Json
+			var dataForV []byte
 			var err error
 
 			// grab the data
 			if v == "$" {
 				dataForV = data
 			} else {
-				dataForV, err = getJSONPath(data, v, spec.Require)
+				dataForV, err = getJSONRaw(data, v, spec.Require)
 				if err != nil {
-					return err
+					return nil, err
 				}
 			}
 
 			// if array flag set, encapsulate data
 			if array {
-				var intSlice = make([]interface{}, 1)
-				intSlice[0] = dataForV.Interface()
-				dataForV.SetPath(nil, intSlice)
+				// bookend() is destructive to underlying slice, need to copy.
+				// extra capacity saves an allocation and copy during bookend.
+				tmp := make([]byte, len(dataForV), len(dataForV)+2)
+				copy(tmp, dataForV)
+				dataForV = bookend(tmp, '[', ']')
 			}
-
-			outData.SetPath(outPath, dataForV.Interface())
+			// Note: following pattern from current Shift() - if multiple elements are included in an array,
+			// they will each successively overwrite each other and only the last element will be included
+			// in the transformed data.
+			outData, err = jsonparser.Set(outData, dataForV, outPath...)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
-	*data = *outData
-	return nil
+	return outData, nil
 }

--- a/transform/shift_test.go
+++ b/transform/shift_test.go
@@ -11,8 +11,8 @@ func TestShift(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
@@ -27,8 +27,24 @@ func TestShiftWithWildcard(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
+		t.FailNow()
+	}
+}
+
+func TestShiftWithWildcardEmptySlice(t *testing.T) {
+	spec := `{"outputArray": "docs[*].data.key"}`
+	jsonIn := `{"docs": []}`
+	jsonOut := `{"outputArray":[]}`
+
+	cfg := getConfig(spec, false)
+	kazaamOut, _ := getTransformTestWrapper(Shift, cfg, jsonIn)
+
+	if kazaamOut != jsonOut {
+		t.Error("Transformed data does not match expectation.")
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
@@ -42,8 +58,8 @@ func TestShiftWithMissingKey(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
@@ -58,8 +74,8 @@ func TestShiftDeepExistsRequire(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
@@ -109,8 +125,8 @@ func TestShiftWithEncapsulate(t *testing.T) {
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }
@@ -125,8 +141,8 @@ func TestShiftWithNullSpecValue(t *testing.T) {
 	errMsg := `Warn: Unknown type in message for key: id`
 	if err.Error() != errMsg {
 		t.Error("Error data does not match expectation.")
-		t.Log("Expected: ", errMsg)
-		t.Log("Actual:   ", err.Error())
+		t.Log("Expected:   ", errMsg)
+		t.Log("Actual:     ", err.Error())
 		t.FailNow()
 	}
 }
@@ -141,8 +157,8 @@ func TestShiftWithNullArraySpecValue(t *testing.T) {
 	errMsg := `Warn: Unable to coerce element to json string: <nil>`
 	if err.Error() != errMsg {
 		t.Error("Error data does not match expectation.")
-		t.Log("Expected: ", errMsg)
-		t.Log("Actual:   ", err.Error())
+		t.Log("Expected:   ", errMsg)
+		t.Log("Actual:     ", err.Error())
 		t.FailNow()
 	}
 }
@@ -153,12 +169,19 @@ func TestShiftWithEndArrayAccess(t *testing.T) {
 	jsonOut := `{"id":"ghi"}`
 
 	cfg := getConfig(spec, false)
-	kazaamOut, _ := getTransformTestWrapper(Shift, cfg, jsonIn)
+	kazaamOut, err := getTransformTestWrapper(Shift, cfg, jsonIn)
+
+	if err != nil {
+		t.Error("Error on transform.")
+		t.Log("Expected: ", jsonOut)
+		t.Log("Error: ", err.Error())
+		t.FailNow()
+	}
 
 	if kazaamOut != jsonOut {
 		t.Error("Transformed data does not match expectation.")
-		t.Log("Expected: ", jsonOut)
-		t.Log("Actual:   ", kazaamOut)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", kazaamOut)
 		t.FailNow()
 	}
 }

--- a/transform/util.go
+++ b/transform/util.go
@@ -2,11 +2,12 @@
 package transform
 
 import (
+	"bytes"
 	"regexp"
 	"strconv"
 	"strings"
 
-	simplejson "github.com/bitly/go-simplejson"
+	"github.com/buger/jsonparser"
 )
 
 // ParseError should be thrown when there is an issue with parsing any the specification or data
@@ -39,68 +40,103 @@ type Config struct {
 
 var jsonPathRe = regexp.MustCompile("([^\\[\\]]+)\\[([0-9\\*]+)\\]")
 
-func getJSONPath(j *simplejson.Json, path string, pathRequired bool) (*simplejson.Json, error) {
-	jin := j
+// Given a json byte slice `data` and a kazaam `path` string, return the object at the path in data if it exists.
+func getJSONRaw(data []byte, path string, pathRequired bool) ([]byte, error) {
 	objectKeys := strings.Split(path, ".")
-	// iterate over each subsequent object key
+	numOfInserts := 0
 	for element, k := range objectKeys {
 		// check the object key to see if it also contains an array reference
-		results := jsonPathRe.FindAllStringSubmatch(k, -1)
-		if results != nil && len(results) > 0 {
-			objKey := results[0][1]      // the key
-			arrayKeyStr := results[0][2] // the array index
+		arrayRefs := jsonPathRe.FindAllStringSubmatch(k, -1)
+		if arrayRefs != nil && len(arrayRefs) > 0 {
+			objKey := arrayRefs[0][1]      // the key
+			arrayKeyStr := arrayRefs[0][2] // the array index
 			// if there's a wildcard array reference
 			if arrayKeyStr == "*" {
-				// get the array
-				var exists bool
-				jin, exists = jin.CheckGet(objKey)
-				if !exists {
-					if pathRequired {
-						return jin, RequireError("Path does not exist")
-					}
-				}
-				arrayLength := len(jin.MustArray())
-				// construct the remainder of the jsonPath
-				newPath := strings.Join(objectKeys[element+1:], ".")
+				// ArrayEach setup
+				objectKeys[element+numOfInserts] = objKey
+				beforePath := objectKeys[:element+numOfInserts+1]
+				newPath := strings.Join(objectKeys[element+numOfInserts+1:], ".")
+				var results [][]byte
 
-				// iterate over each entry
-				var results []interface{}
-				for i := 0; i < arrayLength; i++ {
-					if newPath == "" {
-						results = append(results, jin.GetIndex(i).Interface())
-					} else {
-						intermediate, err := getJSONPath(jin.GetIndex(i), newPath, pathRequired)
+				// use jsonparser.ArrayEach to copy the array into results
+				_, err := jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+					results = append(results, value)
+				}, beforePath...)
+				if err == jsonparser.KeyPathNotFoundError {
+					if pathRequired {
+						return nil, RequireError("Path does not exist")
+					}
+				} else if err != nil {
+					return nil, err
+				}
+
+				// GetJSONRaw() the rest of path for each element in results
+				if newPath != "" {
+					for i, value := range results {
+						intermediate, err := getJSONRaw(value, newPath, pathRequired)
 						if err != nil {
 							return nil, err
 						}
-						results = append(results, intermediate.Interface())
+						results[i] = intermediate
 					}
 				}
 
-				output := simplejson.New()
-				output.SetPath(nil, results)
-				return output, nil
+				// copy into raw []byte format and return
+				var buffer bytes.Buffer
+				buffer.WriteByte('[')
+				for i := 0; i < len(results)-1; i++ {
+					buffer.Write(results[i])
+					buffer.WriteByte(',')
+				}
+				if len(results) > 0 {
+					buffer.Write(results[len(results)-1])
+				}
+				buffer.WriteByte(']')
+				return buffer.Bytes(), nil
 			}
-			arrayKey, err := strconv.Atoi(arrayKeyStr)
+			_, err := strconv.Atoi(arrayKeyStr)
 			if err != nil {
 				return nil, err
 			}
-			jin = jin.Get(objKey).GetIndex(arrayKey)
+			// separate the array key as a new element in objectKeys
+			arrayKey := string(bookend([]byte(arrayKeyStr), '[', ']'))
+			objectKeys[element+numOfInserts] = objKey
+			objectKeys = append(objectKeys, "")
+			copy(objectKeys[element+numOfInserts+2:], objectKeys[element+numOfInserts+1:])
+			objectKeys[element+numOfInserts+1] = arrayKey
+			numOfInserts++
 		} else {
-			// var exists bool
-			// jin, exists = jin.CheckGet(k)
-			// if pathRequired && !exists {
-			// 	return nil, &Error{ErrMsg: fmt.Sprintf("Path does not exist"), ErrType: RequireError}
-			// }
-			if pathRequired {
-				_, exists := jin.CheckGet(k)
-				if !exists {
-					return nil, RequireError("Path does not exist")
-					// return nil, &Error{ErrMsg: fmt.Sprintf("Path does not exist"), ErrType: RequireError}
-				}
-			}
-			jin = jin.Get(k)
+			// no array reference, good to go
+			continue
 		}
 	}
-	return jin, nil
+	result, dataType, _, err := jsonparser.Get(data, objectKeys...)
+
+	// jsonparser strips quotes from Strings
+	if dataType == jsonparser.String {
+		// bookend() is destructive to underlying slice, need to copy.
+		// extra capacity saves an allocation and copy during bookend.
+		tmp := make([]byte, len(result), len(result)+2)
+		copy(tmp, result)
+		result = bookend(tmp, '"', '"')
+	}
+	if len(result) == 0 {
+		result = []byte("null")
+	}
+	if err == jsonparser.KeyPathNotFoundError {
+		if pathRequired {
+			return nil, RequireError("Path does not exist")
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// add characters at beginning and end of []byte
+func bookend(value []byte, bef, aft byte) []byte {
+	value = append(value, ' ', aft)
+	copy(value[1:], value[:len(value)-2])
+	value[0] = bef
+	return value
 }

--- a/transform/util_test.go
+++ b/transform/util_test.go
@@ -2,11 +2,10 @@ package transform
 
 import (
 	"encoding/json"
-
-	simplejson "github.com/bitly/go-simplejson"
+	"testing"
 )
 
-const testJSONInput = `{"rating": {"primary": {"value": 3}, "example": {"value": 3}}}`
+const testJSONInput = `{"rating":{"example":{"value":3},"primary":{"value":3}}}`
 
 func getConfig(spec string, require bool) Config {
 	var f map[string]interface{}
@@ -14,18 +13,33 @@ func getConfig(spec string, require bool) Config {
 	return Config{Spec: &f, Require: require}
 }
 
-func getTransformTestWrapper(tform func(spec *Config, data *simplejson.Json) error, cfg Config, input string) (string, error) {
-	json, e := simplejson.NewJson([]byte(input))
+func getTransformTestWrapper(tform func(spec *Config, data []byte) ([]byte, error), cfg Config, input string) (string, error) {
+	output, e := tform(&cfg, []byte(input))
 	if e != nil {
 		return "", e
 	}
-	e = tform(&cfg, json)
-	if e != nil {
-		return "", e
+	return string(output), nil
+}
+
+func TestBookend(t *testing.T) {
+	input := []byte(`"foo", "bar"`)
+	expected := []byte(`["foo", "bar"]`)
+
+	result := bookend(input, '[', ']')
+	if string(result) != string(expected) {
+		t.Error("Bookend result does not match expectation.")
+		t.Log("Expected: ", expected)
+		t.Log("Actual:   ", result)
+		t.FailNow()
 	}
-	tmp, e := json.MarshalJSON()
-	if e != nil {
-		return "", e
+
+	input = []byte("fooString")
+	expected = []byte(`"fooString"`)
+	result = bookend(input, '"', '"')
+	if string(result) != string(expected) {
+		t.Error("Bookend result does not match expectation.")
+		t.Log("Expected: ", expected)
+		t.Log("Actual:   ", result)
+		t.FailNow()
 	}
-	return string(tmp), nil
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,61 @@
+package kazaam
+
+import (
+	"encoding/json"
+
+	"github.com/buger/jsonparser"
+)
+
+// by default, kazaam does not fully validate input data. Use IsJson()
+// if you need to confirm input is valid before transforming.
+// Note: This operation is very slow and memory/alloc intensive
+// relative to most transforms.
+func IsJson(s []byte) bool {
+	var js map[string]interface{}
+	return json.Unmarshal(s, &js) == nil
+
+}
+
+// experimental fast validation with jsonparser
+func IsJsonFast(s []byte) bool {
+	for _, c := range s {
+		switch c {
+		case ' ', '\n', '\r', '\t':
+			continue
+		case '{':
+			return isJsonInternal(s, jsonparser.Object)
+		case '[':
+			return isJsonInternal(s, jsonparser.Array)
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func isJsonInternal(s []byte, t jsonparser.ValueType) bool {
+	valid := true
+	if t == jsonparser.Array {
+		_, err := jsonparser.ArrayEach(s, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+			if valid {
+				valid = isJsonInternal(value, dataType)
+			}
+		})
+		if err != nil || !valid {
+			return false
+		}
+	} else if t == jsonparser.Object {
+		err := jsonparser.ObjectEach(s, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
+			if valid {
+				valid = isJsonInternal(value, dataType)
+			}
+			return nil
+		})
+		if err != nil || !valid {
+			return false
+		}
+	} else if t == jsonparser.Unknown {
+		return false
+	}
+	return valid
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,108 @@
+package kazaam
+
+import (
+	"testing"
+)
+
+type IsJsonTest struct {
+	json    string
+	valid   bool
+	isArray bool // encoding/json IsJson() does not support arrays
+}
+
+var jsonTests = []IsJsonTest{
+	{
+		json:  `{"key":"value"}`,
+		valid: true,
+	},
+	{
+		json:  `{"bad-data"}`,
+		valid: false,
+	},
+	{
+		json:  `{"text": "RT @PostGradProblem: In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during ...","truncated": true,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54691802283900928","entities": {"user_mentions": [{"indices": [3,19],"screen_name": "PostGradProblem","id_str": "271572434","name": "PostGradProblems","id": 271572434}],"urls": [ ],"hashtags": [ ]},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 23:48:36 +0000 2011","retweeted_status": {"text": "In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during company time. #PGP","truncated": false,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54640519019642881","entities": {"user_mentions": [ ],"urls": [ ],"hashtags": [{"text": "PGP","indices": [130,134]}]},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 20:24:49 +0000 2011","user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 31,"profile_background_color": "C0DEED","followers_count": 3066,"profile_image_url": "http://a2.twimg.com/profile_images/1285770264/PGP_normal.jpg","listed_count": 6,"profile_background_image_url": "http://a3.twimg.com/a/1301071706/images/themes/theme1/bg.png","description": "","screen_name": "PostGradProblem","default_profile": true,"verified": false,"time_zone": null,"profile_text_color": "333333","is_translator": false,"profile_sidebar_fill_color": "DDEEF6","location": "","id_str": "271572434","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 21,"protected": false,"favourites_count": 0,"created_at": "Thu Mar 24 19:45:44 +0000 2011","profile_link_color": "0084B4","name": "PostGradProblems","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 271572434,"contributors_enabled": false,"following": null,"utc_offset": null},"id": 54640519019642880,"coordinates": null,"geo": null},"user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 351,"profile_background_color": "C0DEED","followers_count": 48,"profile_image_url": "http://a1.twimg.com/profile_images/455128973/gCsVUnofNqqyd6tdOGevROvko1_500_normal.jpg","listed_count": 0,"profile_background_image_url": "http://a3.twimg.com/a/1300479984/images/themes/theme1/bg.png","description": "watcha doin in my waters?","screen_name": "OldGREG85","default_profile": true,"verified": false,"time_zone": "Hawaii","profile_text_color": "333333","is_translator": false,"profile_sidebar_fill_color": "DDEEF6","location": "Texas","id_str": "80177619","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 81,"protected": false,"favourites_count": 0,"created_at": "Tue Oct 06 01:13:17 +0000 2009","profile_link_color": "0084B4","name": "GG","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 80177619,"contributors_enabled": false,"following": null,"utc_offset": -36000},"id": 54691802283900930,"coordinates": null,"geo": null}`,
+		valid: true,
+	},
+	{
+		// ,"profile_text_color": "333333","is_translator: false,"profile_sidebar_fill_color": "DDEEF6",
+		json:  `{"text": "RT @PostGradProblem: In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during ...","truncated": true,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54691802283900928","entities": {"user_mentions": [{"indices": [3,19],"screen_name": "PostGradProblem","id_str": "271572434","name": "PostGradProblems","id": 271572434}],"urls": [ ],"hashtags": [ ]},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 23:48:36 +0000 2011","retweeted_status": {"text": "In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during company time. #PGP","truncated": false,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54640519019642881","entities": {"user_mentions": [ ],"urls": [ ],"hashtags": [{"text": "PGP","indices": [130,134]}]},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 20:24:49 +0000 2011","user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 31,"profile_background_color": "C0DEED","followers_count": 3066,"profile_image_url": "http://a2.twimg.com/profile_images/1285770264/PGP_normal.jpg","listed_count": 6,"profile_background_image_url": "http://a3.twimg.com/a/1301071706/images/themes/theme1/bg.png","description": "","screen_name": "PostGradProblem","default_profile": true,"verified": false,"time_zone": null,"profile_text_color": "333333","is_translator": false,"profile_sidebar_fill_color": "DDEEF6","location": "","id_str": "271572434","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 21,"protected": false,"favourites_count": 0,"created_at": "Thu Mar 24 19:45:44 +0000 2011","profile_link_color": "0084B4","name": "PostGradProblems","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 271572434,"contributors_enabled": false,"following": null,"utc_offset": null},"id": 54640519019642880,"coordinates": null,"geo": null},"user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 351,"profile_background_color": "C0DEED","followers_count": 48,"profile_image_url": "http://a1.twimg.com/profile_images/455128973/gCsVUnofNqqyd6tdOGevROvko1_500_normal.jpg","listed_count": 0,"profile_background_image_url": "http://a3.twimg.com/a/1300479984/images/themes/theme1/bg.png","description": "watcha doin in my waters?","screen_name": "OldGREG85","default_profile": true,"verified": false,"time_zone": "Hawaii","profile_text_color": "333333","is_translator: false,"profile_sidebar_fill_color": "DDEEF6","location": "Texas","id_str": "80177619","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 81,"protected": false,"favourites_count": 0,"created_at": "Tue Oct 06 01:13:17 +0000 2009","profile_link_color": "0084B4","name": "GG","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 80177619,"contributors_enabled": false,"following": null,"utc_offset": -36000},"id": 54691802283900930,"coordinates": null,"geo": null}`,
+		valid: false,
+	},
+	{
+		// "hashtags": [{"text": "PGP","indices": [130,134]}},
+		json:  `{"text": "RT @PostGradProblem: In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during ...","truncated": true,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54691802283900928","entities": {"user_mentions": [{"indices": [3,19],"screen_name": "PostGradProblem","id_str": "271572434","name": "PostGradProblems","id": 271572434}],"urls": [ ],"hashtags": [ ]},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 23:48:36 +0000 2011","retweeted_status": {"text": "In preparation for the NFL lockout, I will be spending twice as much time analyzing my fantasy baseball team during company time. #PGP","truncated": false,"in_reply_to_user_id": null,"in_reply_to_status_id": null,"favorited": false,"source": "","in_reply_to_screen_name": null,"in_reply_to_status_id_str": null,"id_str": "54640519019642881","entities": {"user_mentions": [ ],"urls": [ ],"hashtags": [{"text": "PGP","indices": [130,134]}},"contributors": null,"retweeted": false,"in_reply_to_user_id_str": null,"place": null,"retweet_count": 4,"created_at": "Sun Apr 03 20:24:49 +0000 2011","user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 31,"profile_background_color": "C0DEED","followers_count": 3066,"profile_image_url": "http://a2.twimg.com/profile_images/1285770264/PGP_normal.jpg","listed_count": 6,"profile_background_image_url": "http://a3.twimg.com/a/1301071706/images/themes/theme1/bg.png","description": "","screen_name": "PostGradProblem","default_profile": true,"verified": false,"time_zone": null,"profile_text_color": "333333","is_translator": false,"profile_sidebar_fill_color": "DDEEF6","location": "","id_str": "271572434","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 21,"protected": false,"favourites_count": 0,"created_at": "Thu Mar 24 19:45:44 +0000 2011","profile_link_color": "0084B4","name": "PostGradProblems","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 271572434,"contributors_enabled": false,"following": null,"utc_offset": null},"id": 54640519019642880,"coordinates": null,"geo": null},"user": {"notifications": null,"profile_use_background_image": true,"statuses_count": 351,"profile_background_color": "C0DEED","followers_count": 48,"profile_image_url": "http://a1.twimg.com/profile_images/455128973/gCsVUnofNqqyd6tdOGevROvko1_500_normal.jpg","listed_count": 0,"profile_background_image_url": "http://a3.twimg.com/a/1300479984/images/themes/theme1/bg.png","description": "watcha doin in my waters?","screen_name": "OldGREG85","default_profile": true,"verified": false,"time_zone": "Hawaii","profile_text_color": "333333","is_translator": false,"profile_sidebar_fill_color": "DDEEF6","location": "Texas","id_str": "80177619","default_profile_image": false,"profile_background_tile": false,"lang": "en","friends_count": 81,"protected": false,"favourites_count": 0,"created_at": "Tue Oct 06 01:13:17 +0000 2009","profile_link_color": "0084B4","name": "GG","show_all_inline_media": false,"follow_request_sent": null,"geo_enabled": false,"profile_sidebar_border_color": "C0DEED","url": null,"id": 80177619,"contributors_enabled": false,"following": null,"utc_offset": -36000},"id": 54691802283900930,"coordinates": null,"geo": null}`,
+		valid: false,
+	},
+	{
+		json:  `{"bad-key":falre}`,
+		valid: false,
+	},
+	{
+		json:  `{"boolean":true}`,
+		valid: true,
+	},
+	{
+		json:  `{"nums":773,"type":"integer"}`,
+		valid: true,
+	},
+	{
+		json:  `{"empty":null, "foo":["bar", "baz", 83, null]}`,
+		valid: true,
+	},
+	{
+		json:  `this is in no way json`,
+		valid: false,
+	},
+	{
+		json:    `["foo", false, [1, 2, 3], {"key":"value", "bool":false, "empty":null}, "bar"]`,
+		valid:   true,
+		isArray: true,
+	},
+	{
+		json:    `["simple", "array"]`,
+		valid:   true,
+		isArray: true,
+	},
+	{
+		json:    `["invalid", "array]`,
+		valid:   false,
+		isArray: true,
+	},
+	{
+		json:    `[33, false, 77, random, "array"]`,
+		valid:   false,
+		isArray: true,
+	},
+	{
+		json:  `{}`,
+		valid: true,
+	},
+	{
+		json:    `[]`,
+		valid:   true,
+		isArray: true,
+	},
+	{
+		json:  ``,
+		valid: false,
+	},
+	{
+		json:  `"just a string"`,
+		valid: false,
+	},
+}
+
+func TestIsJson(t *testing.T) {
+	for _, jt := range jsonTests {
+		if !jt.isArray && IsJson([]byte(jt.json)) != jt.valid {
+			t.Error("IsJson() failed")
+			t.Log("Json: ", jt.json)
+			t.Log("Expected: ", jt.valid)
+		}
+		if IsJsonFast([]byte(jt.json)) != jt.valid {
+			t.Error("IsJsonFast() failed")
+			t.Log("Json: ", jt.json)
+			t.Log("Expected: ", jt.valid)
+		}
+	}
+}


### PR DESCRIPTION
Kazaam is significantly refactored to use [jsonparser](https://github.com/buger/jsonparser) as the underlying JSON manipulation library, rather than [go-simplejson](https://github.com/bitly/go-simplejson). This results in a 2-10x improvement in time, memory usage and allocations / op for most benchmarks. See details in https://github.com/qntfy/kazaam/pull/35

Kazaam now takes `[]byte` as primary transform input rather than `simplejson.Json` objects. String methods are still supported without change. 

Kazaam no longer provides full JSON validation in all scenarios, but (relatively very slow) `IsJson()` method is provided for convenience for users who wish to validate. Also includes experimental `IsJsonFast()` method which recursively iterates through a json object/array looking for parser errors (we will likely roll this approach into main IsJson() method in a future release).