### PR TITLE
Add in-place option to shift transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/qntfy/kazaam/badge.svg?branch=master)](https://coveralls.io/github/qntfy/kazaam?branch=master)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![GitHub release](https://img.shields.io/github/release/qntfy/kazaam.svg?maxAge=3600)](https://github.com/qntfy/kazaam/releases/latest)
-[![Go Report Card](https://goreportcard.com/badge/github.com/qntfy/kazaam)](https://goreportcard.com/report/github.com/qntfy/kazaam) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/qntfy/kazaam)](https://goreportcard.com/report/github.com/qntfy/kazaam)
 [![GoDoc](https://godoc.org/github.com/qntfy/kazaam?status.svg)](http://godoc.org/gopkg.in/qntfy/kazaam.v3)
 
 ## Description
@@ -92,6 +92,9 @@ The jsonpath implementation supports a few special cases:
 The shift transform also supports a `"require"` field. When set to `true`,
 Kazaam will throw an error if *any* of the paths in the source JSON are not
 present.
+
+Finally, shift by default is destructive. For in-place operation, an optional `"inplace"`
+field may be set.
 
 ### Concat
 The concat transform allows the combination of fields and literal strings into a single string value.
@@ -284,8 +287,8 @@ would result in
 }
 ```
 
-For UUIDv3 & UUIDV5 are a bit more complex. These require a Name Space which is a valid UUID already, and a set of paths, which generate UUID's based on the value of that path. If that path doesn't exist in the incoming document, a default field will be used instead. **Note** both of these fields must be strings. 
-**Additionally** you can use the 4 predefined namespaces such as `DNS`, `URL`, `OID`, & `X500` in the name space field otherwise pass your own UUID. 
+For UUIDv3 & UUIDV5 are a bit more complex. These require a Name Space which is a valid UUID already, and a set of paths, which generate UUID's based on the value of that path. If that path doesn't exist in the incoming document, a default field will be used instead. **Note** both of these fields must be strings.
+**Additionally** you can use the 4 predefined namespaces such as `DNS`, `URL`, `OID`, & `X500` in the name space field otherwise pass your own UUID.
 
 ```javascript
 {

--- a/transform/shift.go
+++ b/transform/shift.go
@@ -8,8 +8,13 @@ import (
 )
 
 // Shift moves values from one provided json path to another in raw []byte.
-func Shift(spec *Config, data []byte) ([]byte, error) {
-	outData := []byte(`{}`)
+func Shift(spec *InPlaceConfig, data []byte) ([]byte, error) {
+	var outData []byte
+	if spec.InPlace {
+		outData = data
+	} else {
+		outData = []byte(`{}`)
+	}
 	for k, v := range *spec.Spec {
 		array := true
 		outPath := strings.Split(k, ".")

--- a/transform/shift.go
+++ b/transform/shift.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Shift moves values from one provided json path to another in raw []byte.
-func Shift(spec *InPlaceConfig, data []byte) ([]byte, error) {
+func Shift(spec *Config, data []byte) ([]byte, error) {
 	var outData []byte
 	if spec.InPlace {
 		outData = data

--- a/transform/shift_test.go
+++ b/transform/shift_test.go
@@ -18,6 +18,24 @@ func TestShift(t *testing.T) {
 	}
 }
 
+func TestShiftInPlace(t *testing.T) {
+	jsonOut := `{"rating":{"example":{"value":3},"primary":{"value":3}},"Rating":3,"example":{"old":{"value":3}}}`
+	spec := `{"Rating": "rating.primary.value", "example.old": "rating.example"}`
+
+	cfg := getConfig(spec, false)
+	cfg.InPlace = true
+	kazaamOut, _ := getTransformTestWrapper(Shift, cfg, testJSONInput)
+	areEqual, _ := checkJSONBytesEqual(kazaamOut, []byte(jsonOut))
+
+	if !areEqual {
+		t.Error("Transformed data does not match expectation.")
+		t.Log("Input:      ", testJSONInput)
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", string(kazaamOut))
+		t.FailNow()
+	}
+}
+
 func TestShiftWithWildcard(t *testing.T) {
 	spec := `{"outputArray": "docs[*].data.key"}`
 	jsonIn := `{"docs": [{"data": {"key": "val1"}},{"data": {"key": "val2"}}]}`

--- a/transform/util.go
+++ b/transform/util.go
@@ -37,6 +37,7 @@ func (s SpecError) Error() string {
 type Config struct {
 	Spec    *map[string]interface{} `json:"spec"`
 	Require bool                    `json:"require,omitempty"`
+	InPlace bool                    `json:"inplace,omitempty"`
 }
 
 var jsonPathRe = regexp.MustCompile("([^\\[\\]]+)\\[(.*?)\\]")


### PR DESCRIPTION
Adds a top-level `in-place` field to spec definitions that can be supported by other transforms in the future.