### PR TITLE
Bug fixes related to #64

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/qntfy/kazaam
 import:
 - package: github.com/qntfy/jsonparser
-  version: ^1.0.0
+  version: ^1.0.1
 - package: github.com/satori/go.uuid
   version: v1.1.0

--- a/transform/coalesce.go
+++ b/transform/coalesce.go
@@ -24,7 +24,6 @@ func Coalesce(spec *Config, data []byte) ([]byte, error) {
 	ignoreSlice := [][]byte{[]byte("null")}
 	ignoreList, ignoreOk := (*spec.Spec)["ignore"]
 	if ignoreOk {
-		delete((*spec.Spec), "ignore")
 		for _, iItem := range ignoreList.([]interface{}) {
 			iByte, err := json.Marshal(iItem)
 			if err != nil {
@@ -35,6 +34,10 @@ func Coalesce(spec *Config, data []byte) ([]byte, error) {
 	}
 
 	for k, v := range *spec.Spec {
+		if k == "ignore" {
+			continue
+		}
+
 		var keyList []string
 
 		// check if `v` is a list and build a list of keys to evaluate

--- a/transform/coalesce_test.go
+++ b/transform/coalesce_test.go
@@ -79,14 +79,14 @@ func TestCoalesceWithIgnore(t *testing.T) {
 	}
 
 	// confirm that no configs were harmed in the making of this transform
-        kazaamOut, _ = getTransformTestWrapper(Coalesce, cfg, jsonInput)
-        areEqual, _ = checkJSONBytesEqual(kazaamOut, []byte(jsonOut))
+	kazaamOut, _ = getTransformTestWrapper(Coalesce, cfg, jsonInput)
+	areEqual, _ = checkJSONBytesEqual(kazaamOut, []byte(jsonOut))
 
-        if !areEqual {
-                t.Error("Transformed data does not match expectation on second iteration.")
-                t.Log("Expected:   ", jsonOut)
-                t.Log("Actual:     ", string(kazaamOut))
-                t.FailNow()
-        }
+	if !areEqual {
+		t.Error("Transformed data does not match expectation on second iteration.")
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", string(kazaamOut))
+		t.FailNow()
+	}
 
 }

--- a/transform/coalesce_test.go
+++ b/transform/coalesce_test.go
@@ -77,4 +77,16 @@ func TestCoalesceWithIgnore(t *testing.T) {
 		t.Log("Actual:     ", string(kazaamOut))
 		t.FailNow()
 	}
+
+	// confirm that no configs were harmed in the making of this transform
+        kazaamOut, _ = getTransformTestWrapper(Coalesce, cfg, jsonInput)
+        areEqual, _ = checkJSONBytesEqual(kazaamOut, []byte(jsonOut))
+
+        if !areEqual {
+                t.Error("Transformed data does not match expectation on second iteration.")
+                t.Log("Expected:   ", jsonOut)
+                t.Log("Actual:     ", string(kazaamOut))
+                t.FailNow()
+        }
+
 }

--- a/transform/shift_test.go
+++ b/transform/shift_test.go
@@ -139,6 +139,30 @@ func TestShiftDeepNoArraysRequire(t *testing.T) {
 	}
 }
 
+func TestShiftDeepTrickyPath(t *testing.T) {
+	spec := `{"Rating": "rating.exist"}`
+	jsonIn := `{"rating":"bar","foo":{"exist":"baz"}}`
+	jsonOut := `{"Rating":null}`
+
+	cfg := getConfig(spec, false)
+	kazaamOut, err := getTransformTestWrapper(Shift, cfg, jsonIn)
+
+	if err != nil {
+		t.Error("Error on transform.")
+		t.Log("Expected: ", jsonOut)
+		t.Log("Error: ", err.Error())
+		t.FailNow()
+	}
+
+	areEqual, _ := checkJSONBytesEqual(kazaamOut, []byte(jsonOut))
+	if !areEqual {
+		t.Error("Transformed data does not match expectation.")
+		t.Log("Expected:   ", jsonOut)
+		t.Log("Actual:     ", string(kazaamOut))
+		t.FailNow()
+	}
+}
+
 func TestShiftWithEncapsulate(t *testing.T) {
 	jsonOut := `{"data":[{"rating":{"example":{"value":3},"primary":{"value":3}}}]}`
 	spec := `{"data": ["$"]}`


### PR DESCRIPTION
`ignore` only worked the first time after `Coalesce()` was initialized.

Also fixes https://github.com/qntfy/jsonparser/issues/3 which could affect most transforms.