### PR TITLE
Fix breaking API change in uuid package

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -3,4 +3,4 @@ import:
 - package: github.com/qntfy/jsonparser
   version: ^1.0.2
 - package: github.com/satori/go.uuid
-  version: v1.1.0
+  version: 36e9d2ebbde5e3f13ab2e25625fd453271d6522e

--- a/transform/uuid.go
+++ b/transform/uuid.go
@@ -30,7 +30,10 @@ func UUID(spec *Config, data []byte) ([]byte, error) {
 
 		switch version {
 		case 4:
-			u = uuid.NewV4()
+			u, err = uuid.NewV4()
+			if err != nil {
+				return nil, err
+			}
 
 		case 3, 5:
 			// choose the correct UUID function


### PR DESCRIPTION
Fixes #69 

uuid package locked to the latest commit because there is no updated tag on the repo.