### PR TITLE
Export helper funcs GetJSONRaw, SetJSONRaw, DelJSONRaw

### DIFF
--- a/transform/coalesce.go
+++ b/transform/coalesce.go
@@ -60,12 +60,12 @@ func Coalesce(spec *Config, data []byte) ([]byte, error) {
 			var err error
 
 			// grab the data
-			dataForV, err = getJSONRaw(data, v, false)
+			dataForV, err = GetJSONRaw(data, v, false)
 			if err != nil {
 				return nil, err
 			}
 			if !inArray(dataForV, ignoreSlice) {
-				data, err = setJSONRaw(data, dataForV, k)
+				data, err = SetJSONRaw(data, dataForV, k)
 				if err != nil {
 					return nil, err
 				}

--- a/transform/concat.go
+++ b/transform/concat.go
@@ -33,7 +33,7 @@ func Concat(spec *Config, data []byte) ([]byte, error) {
 		if !ok {
 			path, ok := vItem.(map[string]interface{})["path"]
 			if ok {
-				zed, err := getJSONRaw(data, path.(string), spec.Require)
+				zed, err := GetJSONRaw(data, path.(string), spec.Require)
 				switch {
 				case err != nil && spec.Require == true:
 					return nil, RequireError("Path does not exist")
@@ -63,7 +63,7 @@ func Concat(spec *Config, data []byte) ([]byte, error) {
 
 		applyDelim = true
 	}
-	data, err := setJSONRaw(data, bookend([]byte(outString), '"', '"'), targetPath.(string))
+	data, err := SetJSONRaw(data, bookend([]byte(outString), '"', '"'), targetPath.(string))
 	if err != nil {
 		return nil, err
 	}

--- a/transform/default.go
+++ b/transform/default.go
@@ -13,7 +13,7 @@ func Default(spec *Config, data []byte) ([]byte, error) {
 		if err != nil {
 			return nil, ParseError(fmt.Sprintf("Warn: Unable to coerce element to json string: %v", v))
 		}
-		data, err = setJSONRaw(data, dataForV, k)
+		data, err = SetJSONRaw(data, dataForV, k)
 		if err != nil {
 			return nil, err
 		}

--- a/transform/delete.go
+++ b/transform/delete.go
@@ -22,7 +22,7 @@ func Delete(spec *Config, data []byte) ([]byte, error) {
 		}
 
 		var err error
-		data, err = delJSONRaw(data, path, spec.Require)
+		data, err = DelJSONRaw(data, path, spec.Require)
 		if err != nil {
 			return nil, err
 		}

--- a/transform/extract.go
+++ b/transform/extract.go
@@ -6,7 +6,7 @@ func Extract(spec *Config, data []byte) ([]byte, error) {
 	if !ok {
 		return nil, SpecError("Unable to get path")
 	}
-	result, err := getJSONRaw(data, outPath.(string), spec.Require)
+	result, err := GetJSONRaw(data, outPath.(string), spec.Require)
 	if err != nil {
 		return nil, err
 	}

--- a/transform/shift.go
+++ b/transform/shift.go
@@ -48,7 +48,7 @@ func Shift(spec *Config, data []byte) ([]byte, error) {
 			if v == "$" {
 				dataForV = data
 			} else {
-				dataForV, err = getJSONRaw(data, v, spec.Require)
+				dataForV, err = GetJSONRaw(data, v, spec.Require)
 				if err != nil {
 					return nil, err
 				}
@@ -65,7 +65,7 @@ func Shift(spec *Config, data []byte) ([]byte, error) {
 			// Note: following pattern from current Shift() - if multiple elements are included in an array,
 			// they will each successively overwrite each other and only the last element will be included
 			// in the transformed data.
-			outData, err = setJSONRaw(outData, dataForV, k)
+			outData, err = SetJSONRaw(outData, dataForV, k)
 			if err != nil {
 				return nil, err
 			}

--- a/transform/timestamp.go
+++ b/transform/timestamp.go
@@ -46,7 +46,7 @@ func Timestamp(spec *Config, data []byte) ([]byte, error) {
 			inputFormat = time.RFC3339
 		} else {
 			// grab the data
-			dataForV, err = getJSONRaw(data, k, spec.Require)
+			dataForV, err = GetJSONRaw(data, k, spec.Require)
 			if err != nil {
 				return nil, err
 			}
@@ -63,7 +63,7 @@ func Timestamp(spec *Config, data []byte) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			data, err = setJSONRaw(data, []byte(formattedItem), k)
+			data, err = SetJSONRaw(data, []byte(formattedItem), k)
 			if err != nil {
 				return nil, err
 			}
@@ -82,7 +82,7 @@ func Timestamp(spec *Config, data []byte) ([]byte, error) {
 				}
 				// replacing the wildcard here feels hacky, but seems to be the
 				// quickest way to achieve the outcome we want
-				data, err = setJSONRaw(data, []byte(formattedItem), strings.Replace(k, "*", strconv.Itoa(idx), -1))
+				data, err = SetJSONRaw(data, []byte(formattedItem), strings.Replace(k, "*", strconv.Itoa(idx), -1))
 				if err != nil {
 					return nil, err
 				}

--- a/transform/util.go
+++ b/transform/util.go
@@ -46,7 +46,7 @@ var (
 )
 
 // Given a json byte slice `data` and a kazaam `path` string, return the object at the path in data if it exists.
-func getJSONRaw(data []byte, path string, pathRequired bool) ([]byte, error) {
+func GetJSONRaw(data []byte, path string, pathRequired bool) ([]byte, error) {
 	objectKeys := strings.Split(path, ".")
 	numOfInserts := 0
 	for element, k := range objectKeys {
@@ -82,7 +82,7 @@ func getJSONRaw(data []byte, path string, pathRequired bool) ([]byte, error) {
 				// GetJSONRaw() the rest of path for each element in results
 				if newPath != "" {
 					for i, value := range results {
-						intermediate, err := getJSONRaw(value, newPath, pathRequired)
+						intermediate, err := GetJSONRaw(value, newPath, pathRequired)
 						if err == jsonparser.KeyPathNotFoundError {
 							if pathRequired {
 								return nil, NonExistentPath
@@ -136,8 +136,8 @@ func getJSONRaw(data []byte, path string, pathRequired bool) ([]byte, error) {
 	return result, nil
 }
 
-// setJSONRaw sets the value at a key and handles array indexing
-func setJSONRaw(data, out []byte, path string) ([]byte, error) {
+// SetJSONRaw sets the value at a key and handles array indexing
+func SetJSONRaw(data, out []byte, path string) ([]byte, error) {
 	var err error
 	splitPath := strings.Split(path, ".")
 	numOfInserts := 0
@@ -169,7 +169,7 @@ func setJSONRaw(data, out []byte, path string) ([]byte, error) {
 					return nil, err
 				}
 
-				// setJSONRaw() the rest of path for each element in results
+				// SetJSONRaw() the rest of path for each element in results
 				for i := 0; i < arraySize; i++ {
 					var newPath string
 					// iterate through each item in the array by replacing the
@@ -186,7 +186,7 @@ func setJSONRaw(data, out []byte, path string) ([]byte, error) {
 					}
 					// now call the function, but this time with an array index
 					// instead of a wildcard
-					data, err = setJSONRaw(data, out, newPath)
+					data, err = SetJSONRaw(data, out, newPath)
 					if err != nil {
 						return nil, err
 					}
@@ -208,8 +208,8 @@ func setJSONRaw(data, out []byte, path string) ([]byte, error) {
 	return data, nil
 }
 
-// delJSONRaw deletes the value at a path and handles array indexing
-func delJSONRaw(data []byte, path string, pathRequired bool) ([]byte, error) {
+// DelJSONRaw deletes the value at a path and handles array indexing
+func DelJSONRaw(data []byte, path string, pathRequired bool) ([]byte, error) {
 	var err error
 	splitPath := strings.Split(path, ".")
 	numOfInserts := 0

--- a/transform/util_test.go
+++ b/transform/util_test.go
@@ -104,7 +104,7 @@ func TestSetJSONRaw(t *testing.T) {
 		{[]byte(`{"data":["value"]}`), []byte(`"newValue"`), "data[+]", []byte(`{"data":["value","newValue"]}`)},
 	}
 	for _, testItem := range setPathTests {
-		actual, _ := setJSONRaw(testItem.inputData, testItem.inputValue, testItem.path)
+		actual, _ := SetJSONRaw(testItem.inputData, testItem.inputValue, testItem.path)
 		areEqual, _ := checkJSONBytesEqual(actual, testItem.expectedOutput)
 		if !areEqual {
 			t.Error("Error data does not match expectation.")
@@ -115,7 +115,7 @@ func TestSetJSONRaw(t *testing.T) {
 }
 
 func TestSetJSONRawBadIndex(t *testing.T) {
-	_, err := setJSONRaw([]byte(`{"data":["value"]}`), []byte(`"newValue"`), "data[g].key")
+	_, err := SetJSONRaw([]byte(`{"data":["value"]}`), []byte(`"newValue"`), "data[g].key")
 
 	errMsg := `Warn: Unable to coerce index to integer: g`
 	if err.Error() != errMsg {
@@ -143,7 +143,7 @@ func TestGetJSONRaw(t *testing.T) {
 		{[]byte(`{"data":{"subData":[{"key": "value"}, {"key": "value"}]}}`), "data.subData[*].key", true, []byte(`["value","value"]`)},
 	}
 	for _, testItem := range getPathTests {
-		actual, _ := getJSONRaw(testItem.inputData, testItem.path, testItem.required)
+		actual, _ := GetJSONRaw(testItem.inputData, testItem.path, testItem.required)
 		areEqual, _ := checkJSONBytesEqual(actual, testItem.expectedOutput)
 		if !areEqual {
 			t.Error("Error data does not match expectation.")
@@ -154,7 +154,7 @@ func TestGetJSONRaw(t *testing.T) {
 }
 
 func TestGetJSONRawBadIndex(t *testing.T) {
-	_, err := getJSONRaw([]byte(`{"data":["value"]}`), "data[-1].key", true)
+	_, err := GetJSONRaw([]byte(`{"data":["value"]}`), "data[-1].key", true)
 
 	errMsg := `Warn: Unable to coerce index to integer: -1`
 	if err.Error() != errMsg {

--- a/transform/uuid.go
+++ b/transform/uuid.go
@@ -67,7 +67,7 @@ func UUID(spec *Config, data []byte) ([]byte, error) {
 			for _, field := range nameFields {
 				p, _ := field.(map[string]interface{})["path"].(string)
 
-				name, pathErr := getJSONRaw(data, p, true)
+				name, pathErr := GetJSONRaw(data, p, true)
 				// if a string, remove the heading and trailing quote
 				nameString := strings.TrimPrefix(strings.TrimSuffix(string(name), "\""), "\"")
 				if pathErr == NonExistentPath {
@@ -84,7 +84,7 @@ func UUID(spec *Config, data []byte) ([]byte, error) {
 
 		}
 		// set the uuid in the appropraite place
-		data, err = setJSONRaw(data, bookend([]byte(u.String()), '"', '"'), k)
+		data, err = SetJSONRaw(data, bookend([]byte(u.String()), '"', '"'), k)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This change exports the functions `GetJSONRaw`, `SetJSONRaw`, and `DelJSONRaw`.

When writing your own custom transformers, these functions greatly reduce your own boilerplate.