### PR TITLE
update UUID dependency

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -3,4 +3,4 @@ import:
 - package: github.com/qntfy/jsonparser
   version: ^1.0.2
 - package: github.com/satori/go.uuid
-  version: 36e9d2ebbde5e3f13ab2e25625fd453271d6522e
+  version: ^1.2.0

--- a/transform/uuid.go
+++ b/transform/uuid.go
@@ -30,10 +30,7 @@ func UUID(spec *Config, data []byte) ([]byte, error) {
 
 		switch version {
 		case 4:
-			u, err = uuid.NewV4()
-			if err != nil {
-				return nil, err
-			}
+			u = uuid.NewV4()
 
 		case 3, 5:
 			// choose the correct UUID function


### PR DESCRIPTION
because this is pinned to an old version of the UUID library, it won't work transitively when `kazaam` is a dependency of other golang projects