### PR TITLE
feature: timestamp can now be used with milli format, as used in many IoT systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,20 +229,25 @@ supports the `$now` operator for `inputFormat`, which will set the current
 timestamp at the specified path, formatted according to the `outputFormat`.
 `$unix` is supported for both input and output formats as a Unix time, the
 number of seconds elapsed since January 1, 1970 UTC as an integer string.
+Usage of `$unixext` will reference to unix number of milliseconds since 
+January 1, 1970 UTC .
+
 ```javascript
 {
   "operation": "timestamp",
-  "timestamp[0]": {
-    "inputFormat": "Mon Jan _2 15:04:05 -0700 2006",
-    "outputFormat": "2006-01-02T15:04:05-0700"
-  },
-  "nowTimestamp": {
-    "inputFormat": "$now",
-    "outputFormat": "2006-01-02T15:04:05-0700"
-  },
-  "epochTimestamp": {
-    "inputFormat": "2006-01-02T15:04:05-0700",
-    "outputFormat": "$unix"
+  "spec": {
+    "timestamp[0]": {
+      "inputFormat": "Mon Jan _2 15:04:05 -0700 2006",
+      "outputFormat": "2006-01-02T15:04:05-0700"
+    },
+    "nowTimestamp": {
+      "inputFormat": "$now",
+      "outputFormat": "2006-01-02T15:04:05-0700"
+    },
+    "epochTimestamp": {
+      "inputFormat": "2006-01-02T15:04:05-0000",
+      "outputFormat": "$unix"
+    }
   }
 }
 
@@ -266,8 +271,9 @@ would result in
     "2017-07-22T08:15:27+0000",
     "Sun Jul 23 08:15:27 +0000 2017",
     "Mon Jul 24 08:15:27 +0000 2017"
-  ]
-  "nowTimestamp": "2017-09-08T19:15:27+0000"
+  ],
+  "nowTimestamp": "2017-09-08T19:15:27+0000",
+  "epochTimestamp": 1136210645
 }
 ```
 

--- a/transform/timestamp.go
+++ b/transform/timestamp.go
@@ -14,6 +14,7 @@ import (
 var now = time.Now
 
 const unixFormat = "$unix"
+const unixExtendedFormat = "$unixext"
 
 // Timestamp parses and formats timestamp strings using the golang syntax
 func Timestamp(spec *Config, data []byte) ([]byte, error) {
@@ -110,6 +111,12 @@ func parseAndFormatValue(inputFormat, outputFormat, unformattedItem string) (str
 			return "", err
 		}
 		parsedItem = time.Unix(i, 0)
+	} else if inputFormat == unixExtendedFormat {
+		i, err := strconv.ParseInt(unformattedItem, 10, 64)
+		if err != nil {
+			return "", err
+		}
+		parsedItem = time.Unix(0, int64(i)*int64(time.Millisecond))
 	} else {
 		parsedItem, err = time.Parse(inputFormat, unformattedItem)
 		if err != nil {
@@ -119,6 +126,8 @@ func parseAndFormatValue(inputFormat, outputFormat, unformattedItem string) (str
 
 	if outputFormat == unixFormat {
 		formattedItem = strconv.FormatInt(parsedItem.Unix(), 10)
+	} else if outputFormat == unixExtendedFormat {
+		formattedItem = strconv.FormatInt(parsedItem.UnixNano()/1000000, 10)
 	} else {
 		formattedItem = parsedItem.Format(outputFormat)
 	}

--- a/transform/timestamp_test.go
+++ b/transform/timestamp_test.go
@@ -170,6 +170,7 @@ func TestParseAndFormatValue(t *testing.T) {
 		{time.RFC3339, "\"2017-07-21T08:15:27+01:00\""},
 		{time.StampNano, "\"Jul 21 08:15:27.000000000\""},
 		{"$unix", "\"1500621327\""},
+		{"$unixext", "\"1500621327000\""},
 	}
 	for _, testItem := range parseAndFormatTests {
 		actual, _ := parseAndFormatValue(inputFormat, testItem.outputFormat, inputTimestamp)
@@ -194,9 +195,35 @@ func TestParseAndFormatValueOutputUnix(t *testing.T) {
 		{time.UnixDate, "Fri Jul 21 08:15:27 GMT 2017", "\"1500624927\""},
 		{time.RFC3339, "2017-07-21T08:15:27+01:00", "\"1500621327\""},
 		{"$unix", "1500621327", "\"1500621327\""},
+		{"$unixext", "1500621327567", "\"1500621327\""},
 	}
 	for _, testItem := range parseAndFormatTests {
 		actual, _ := parseAndFormatValue(testItem.inputFormat, "$unix", testItem.inputTimestamp)
+		if actual != testItem.expectedOutput {
+			t.Error("Error data does not match expectation.", testItem.inputFormat)
+			t.Log("Expected:   ", testItem.expectedOutput)
+			t.Log("Actual:     ", actual)
+		}
+	}
+}
+
+func TestParseAndFormatValueOutputUnixExt(t *testing.T) {
+	parseAndFormatTests := []struct {
+		inputFormat    string
+		inputTimestamp string
+		expectedOutput string
+	}{
+		// test against a sampling of common formats
+		{"2006-01-02T15:04:05-0700", "2017-07-21T08:15:27+0100", "\"1500621327000\""},
+		{"January _2, 2006", "July 21, 2017", "\"1500595200000\""},
+		{time.ANSIC, "Fri Jul 21 08:15:27 2017", "\"1500624927000\""},
+		{time.UnixDate, "Fri Jul 21 08:15:27 GMT 2017", "\"1500624927000\""},
+		{time.RFC3339, "2017-07-21T08:15:27+01:00", "\"1500621327000\""},
+		{"$unix", "1500621327", "\"1500621327000\""},
+		{"$unixext", "1500621327234", "\"1500621327234\""},
+	}
+	for _, testItem := range parseAndFormatTests {
+		actual, _ := parseAndFormatValue(testItem.inputFormat, "$unixext", testItem.inputTimestamp)
 		if actual != testItem.expectedOutput {
 			t.Error("Error data does not match expectation.", testItem.inputFormat)
 			t.Log("Expected:   ", testItem.expectedOutput)


### PR DESCRIPTION
Update the documentation and Tests, too
Bug: adding the spec, and missing comma to the documentation